### PR TITLE
Fix compilation issues after updating async-std to 0.99.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 httparse = "1.3.3"
 http = "0.1.17"
 futures-io-preview = "0.3.0-alpha.18"
-async-std = "0.99.4"
+async-std = "0.99.8"
 futures-core-preview = "0.3.0-alpha.18"
 
 [dev-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,12 +2,12 @@
 
 // use async_std::io::{self, BufRead, BufReader, Read};
 // use async_std::task::{Context, Poll};
-use futures_io::AsyncRead;
-use http::{Request, Response};
+// use futures_io::AsyncRead;
+// use http::{Request, Response};
 
 // use std::pin::Pin;
 
-use crate::{Body, Exception};
+// use crate::{Body, Exception};
 
 /// An HTTP encoder.
 #[derive(Debug)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 //! Process HTTP connections on the server.
 
-use async_std::io::{self, BufRead, BufReader};
+use async_std::io::{self, BufReader};
+use async_std::prelude::*;
 use async_std::task::{Context, Poll};
 use futures_core::ready;
 use futures_io::AsyncRead;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 fn server() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     use async_h1::server;
     use async_std::prelude::*;
-    use async_std::{net, task, io};
+    use async_std::{io, net, task};
 
     task::block_on(async {
         let server = task::spawn(async {
@@ -17,7 +17,8 @@ fn server() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
                 let (reader, writer) = &mut (&stream, &stream);
                 let req = server::decode(reader).await?;
                 dbg!(req);
-                let res = http::Response::new(async_h1::Body {});
+                let body: async_h1::Body<&[u8]> = async_h1::Body::empty();
+                let res = http::Response::new(body);
                 let mut res = server::encode(res).await?;
                 io::copy(&mut res, writer).await?;
             }


### PR DESCRIPTION
Update `async-std` to v0.99.8

## Description
This should be the minimum to get the crate actually building and the tests passing.

