### PR TITLE
Issue 8: Normalize headers and make use of content-length value

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -31,6 +31,14 @@ impl<R: AsyncRead> Body<R> {
         }
     }
 
+    /// Create a new instance from a reader with a known size.
+    pub fn new_with_size(reader: R, size: usize) -> Self {
+        Self {
+            reader,
+            length: Some(size),
+        }
+    }
+
     /// Create a new empty body.
     pub fn empty(reader: R) -> Self {
         Self {

--- a/src/server.rs
+++ b/src/server.rs
@@ -210,9 +210,20 @@ where
     let body = match httparse_req
         .headers
         .iter()
-        .find(|h| h.name == "Content-Length")
+        .find(|h| h.name.eq_ignore_ascii_case("Content-Length"))
     {
-        Some(_header) => Body::new(reader), // TODO: use the header value
+        Some(content_length) => {
+            let length = std::str::from_utf8(content_length.value)
+                .ok()
+                .map(|s| s.parse::<usize>().ok())
+                .flatten();
+
+            if let Some(len) = length {
+                Body::new_with_size(reader, len)
+            } else {
+                return Err("Invalid value for Content-Length".into());
+            }
+        }
         None => Body::empty(reader),
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR normalizes the content-length header so we do not depend on the character casing.  Additionally this PR extracts the content-length value from the headers and adds a `new_with_size` method to the `Body` type, passing the content-length value as an argument.  
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is motivated by the existing bug #8.  
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
