### PR TITLE
Temp fix to get around the fact we can't parse relative urls

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -20,7 +20,9 @@ fn main() -> Result<(), async_h1::Exception> {
                     async { Ok(Response::new(StatusCode::Ok)) }
                 })
                 .await
-            });
+            })
+            .await
+            .unwrap();
         }
         Ok(())
     })


### PR DESCRIPTION
We are currently failing to parse request's `URL` because the request as it comes into the server must only contain the path. Many clients will send the `Host` as a header so for now, we're getting that header's value and concatenating with the path to get a full URL. 

The real fix will be to be able to supply requests with relative urls. This is a bit unfortunate as `Request` objects used  by clients _must_ have full urls associated with them. 