### PR TITLE
Add Date header as necessary

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use async_std::prelude::*;
 use async_std::task::{Context, Poll};
 use futures_core::ready;
 use http_types::{
-    headers::{HeaderName, HeaderValue, CONTENT_LENGTH, TRANSFER_ENCODING, DATE},
+    headers::{HeaderName, HeaderValue, CONTENT_LENGTH, DATE, TRANSFER_ENCODING},
     Body, Request, Response, StatusCode,
 };
 
@@ -13,8 +13,8 @@ use std::pin::Pin;
 use std::str::FromStr;
 
 use crate::chunked::ChunkedDecoder;
-use crate::error::HttpError;
 use crate::date::fmt_http_date;
+use crate::error::HttpError;
 use crate::{Exception, MAX_HEADERS};
 
 /// An HTTP encoder.
@@ -80,7 +80,7 @@ pub async fn encode(req: Request) -> Result<Encoder, std::io::Error> {
     }
 
     let date = fmt_http_date(std::time::SystemTime::now());
-    buf.write_all(b"Date: ").await?;
+    buf.write_all(b"date: ").await?;
     buf.write_all(date.as_bytes()).await?;
     buf.write_all(b"\r\n").await?;
 
@@ -145,9 +145,7 @@ where
 
     if res.header(&DATE).is_none() {
         let date = fmt_http_date(std::time::SystemTime::now());
-        buf.write_all(b"Date: ").await?;
-        buf.write_all(date.as_bytes()).await?;
-        buf.write_all(b"\r\n").await?;
+        res.insert_header(DATE, &format!("date: {}\r\n", date)[..])?;
     }
 
     let content_length = res.header(&CONTENT_LENGTH);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,0 +1,42 @@
+use crate::common::{fixture_path, munge_date};
+use async_h1::client;
+use async_std::fs::File;
+use async_std::io::SeekFrom;
+use async_std::prelude::*;
+use http_types::{headers, Method, Request};
+use url::Url;
+
+mod common;
+
+#[async_std::test]
+async fn test_encode_request_add_date() {
+    let mut request_fixture = File::open(fixture_path("fixtures/client-request1.txt"))
+        .await
+        .unwrap();
+    let mut expected = String::new();
+    request_fixture.read_to_string(&mut expected).await.unwrap();
+
+    let url = Url::parse("http://example.com").unwrap();
+    let req = Request::new(Method::Get, url);
+
+    let mut encoded_req = client::encode(req).await.unwrap();
+
+    let mut actual = String::new();
+    encoded_req.read_to_string(&mut actual).await.unwrap();
+
+    munge_date(&mut expected, &mut actual);
+
+    pretty_assertions::assert_eq!(actual, expected);
+}
+
+#[async_std::test]
+async fn test_response_no_date() {
+    let mut response_fixture = File::open(fixture_path("fixtures/response-no-date.txt"))
+        .await
+        .unwrap();
+    response_fixture.seek(SeekFrom::Start(0)).await.unwrap();
+
+    let res = client::decode(response_fixture).await.unwrap();
+
+    pretty_assertions::assert_eq!(res.header(&headers::DATE).is_some(), true);
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -70,27 +70,30 @@ impl TestCase {
         assert!(!expected.is_empty(), "Missing expected fixture");
 
         // munge actual and expected so that we don't rely on dates matching exactly
-        match expected.find("{DATE}") {
-            Some(i) => {
-                expected.replace_range(i..i + 6, "");
-                match expected.get(i..i + 1) {
-                    Some(byte) => {
-                        let j = actual[i..].find(byte).expect("Byte not found");
-                        actual.replace_range(i..i + j, "");
-                    }
-                    None => expected.replace_range(i.., ""),
-                }
-            }
-            None => {}
-        }
-
+        munge_date(&mut expected, &mut actual);
         pretty_assertions::assert_eq!(actual, expected);
     }
 }
 
-fn fixture_path(relative_path: &str) -> PathBuf {
+pub(crate) fn fixture_path(relative_path: &str) -> PathBuf {
     let directory: PathBuf = env!("CARGO_MANIFEST_DIR").into();
     directory.join("tests").join(relative_path)
+}
+
+pub(crate) fn munge_date(expected: &mut String, actual: &mut String) {
+    match expected.find("{DATE}") {
+        Some(i) => {
+            expected.replace_range(i..i + 6, "");
+            match expected.get(i..i + 1) {
+                Some(byte) => {
+                    let j = actual[i..].find(byte).expect("Byte not found");
+                    actual.replace_range(i..i + j, "");
+                }
+                None => expected.replace_range(i.., ""),
+            }
+        }
+        None => {}
+    }
 }
 
 impl Read for TestCase {

--- a/tests/fixtures/client-request1.txt
+++ b/tests/fixtures/client-request1.txt
@@ -1,0 +1,4 @@
+GET / HTTP/1.1
+content-length: 0
+date: {DATE}
+

--- a/tests/fixtures/request-chunked-basic.txt
+++ b/tests/fixtures/request-chunked-basic.txt
@@ -1,4 +1,4 @@
 GET / HTTP/1.1
-Host: example.com
-User-Agent: curl/7.54.0
+host: example.com
+user-agent: curl/7.54.0
 

--- a/tests/fixtures/request-chunked-echo.txt
+++ b/tests/fixtures/request-chunked-echo.txt
@@ -1,8 +1,8 @@
 GET / HTTP/1.1
-Host: example.com
-User-Agent: curl/7.54.0
-Content-Type: text/plain
-Transfer-Encoding: chunked
+host: example.com
+user-agent: curl/7.54.0
+content-type: text/plain
+transfer-encoding: chunked
 
 7
 Mozilla

--- a/tests/fixtures/request1.txt
+++ b/tests/fixtures/request1.txt
@@ -1,7 +1,7 @@
 POST / HTTP/1.1
-Host: localhost:8080
-User-Agent: curl/7.54.0
-Accept: */*
-Content-Length: 2
-Content-Type: application/x-www-form-urlencoded
+host: localhost:8080
+user-agent: curl/7.54.0
+accept: */*
+content-length: 2
+content-type: application/x-www-form-urlencoded
 

--- a/tests/fixtures/response-no-date.txt
+++ b/tests/fixtures/response-no-date.txt
@@ -1,0 +1,4 @@
+HTTP/1.1 200 OK
+transfer-encoding: chunked
+content-type: text/plain
+


### PR DESCRIPTION
This PR follows up on #6 and adds the Date header to requests sent by the client.  Additionally we should consider dealing with the case described in this RFC https://tools.ietf.org/html/rfc7231#section-7.1.1.2.  

Specifically, ```   A recipient with a clock that receives a response message without a
   Date header field MUST record the time it was received and append a
   corresponding Date header field to the message's header section if it
   is cached or forwarded downstream.```

So that means if we are a client, and we decode a response that does not contain a `Date` header, then we should append the `Date` header to the response before surfacing it to the user.  I am not sure how to conditionally check if the response is cached or forwarded downstream though.  