### PR TITLE
Remove unneeded async-std features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 url = "2.1.0"
 httparse = "1.3.3"
-async-std = { version = "1.4.0", features = ["unstable"] }
+async-std = { version = "1.4.0", default-features = false }
 http-types = { path = '../http-types' }
 pin-project-lite = "0.1.1"
 byte-pool = "0.2.1"


### PR DESCRIPTION
async-h1 builds and works with async-std default-features off and doesn't need unstable.