### PR TITLE
Fix panic with invalid trailer

### DIFF
--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -482,7 +482,9 @@ fn decode_trailer(buffer: Block<'static>, pos: &Range<usize>) -> io::Result<Deco
             let mut trailers = Trailers::new();
             for header in headers {
                 let value = std::string::String::from_utf8_lossy(header.value).to_string();
-                trailers.insert(header.name, value).unwrap();
+                if let Err(err) = trailers.insert(header.name, value) {
+                    return Err(io::Error::new(io::ErrorKind::Other, err.to_string()));
+                }
             }
 
             Ok(DecodeResult::Some {

--- a/tests/fixtures/request-invalid-trailer.txt
+++ b/tests/fixtures/request-invalid-trailer.txt
@@ -1,0 +1,8 @@
+GET / HTTP/1.1
+content-type: application/octet-stream
+transfer-encoding: chunked
+trailer: x-invalid
+
+0
+x-invalid: å
+


### PR DESCRIPTION
Found during fuzz testing. This fixes a panic by propagating `Result` value. Thanks!