### PR TITLE
Add rustfmt configuration

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+newline_style = "Unix"


### PR DESCRIPTION
We use `rustfmt` in this project to format code.  However, if someone
were to have his or her own local rustfmt configuration, that person's
configuration would be in effect when running rustfmt on this project,
potentially leading to inconsistent formatting.

Let's add a `rustfmt.toml` file.  That way, our own configuration will
always be used, as per-project configuration overrides any per-user
configuration.

With the configuration we're adding in this commit, rustfmt does not
make any changes when run.