### PR TITLE
Fix/ignore clippy warnings

### DIFF
--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -115,15 +115,13 @@ impl<R: Read + Unpin> ChunkedDecoder<R> {
                     pending: false,
                 })
             }
-            Poll::Pending => {
-                return Ok(DecodeResult::Some {
-                    read: 0,
-                    new_state: Some(State::Chunk(new_current, len)),
-                    new_pos,
-                    buffer,
-                    pending: true,
-                });
-            }
+            Poll::Pending => Ok(DecodeResult::Some {
+                read: 0,
+                new_state: Some(State::Chunk(new_current, len)),
+                new_pos,
+                buffer,
+                pending: true,
+            }),
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -207,12 +207,9 @@ where
     }
 
     // Check for Content-Length.
-    match content_length {
-        Some(len) => {
-            let len = len.last().unwrap().as_str().parse::<usize>()?;
-            res.set_body(Body::from_reader(reader.take(len as u64), Some(len)));
-        }
-        None => {}
+    if let Some(len) = content_length {
+        let len = len.last().unwrap().as_str().parse::<usize>()?;
+        res.set_body(Body::from_reader(reader.take(len as u64), Some(len)));
     }
 
     // Return the response.
@@ -231,7 +228,7 @@ impl Read for Encoder {
         if !self.headers_done {
             let len = std::cmp::min(self.headers.len() - self.cursor, buf.len());
             let range = self.cursor..self.cursor + len;
-            buf[0..len].copy_from_slice(&mut self.headers[range]);
+            buf[0..len].copy_from_slice(&self.headers[range]);
             self.cursor += len;
             if self.cursor == self.headers.len() {
                 self.headers_done = true;

--- a/src/date.rs
+++ b/src/date.rs
@@ -51,7 +51,7 @@ pub(crate) fn fmt_http_date(d: SystemTime) -> String {
 }
 
 impl HttpDate {
-    fn is_valid(&self) -> bool {
+    fn is_valid(self) -> bool {
         self.second < 60
             && self.minute < 60
             && self.hour < 24
@@ -160,8 +160,8 @@ fn parse_rfc850_date(s: &[u8]) -> http_types::Result<HttpDate> {
             b"-Dec-" => 12,
             _ => bail!("Invalid month"),
         },
-        year: year,
-        week_day: week_day,
+        year,
+        week_day,
     })
 }
 
@@ -407,7 +407,7 @@ impl PartialOrd for HttpDate {
 }
 
 fn is_leap_year(year: u16) -> bool {
-    year % 4 == 0 && (!(year % 100 == 0) || year % 400 == 0)
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,10 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
+#![allow(clippy::if_same_then_else)]
+#![allow(clippy::len_zero)]
+#![allow(clippy::match_bool)]
+#![allow(clippy::unreadable_literal)]
 
 /// The maximum amount of headers parsed on the server.
 const MAX_HEADERS: usize = 128;

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,7 +46,7 @@ where
         let req = match timeout(timeout_duration, decode(addr, io.clone())).await {
             Ok(Ok(Some(r))) => r,
             Ok(Ok(None)) | Err(TimeoutError { .. }) => break, /* EOF or timeout */
-            Ok(Err(e)) => return Err(e).into(),
+            Ok(Err(e)) => return Err(e),
         };
 
         // Pass the request to the endpoint and encode the response.


### PR DESCRIPTION
Clippy has some warnings for us.  For some of them, fixing the code
improves things.  For others, making clippy happy would make the code
worse (or in one case, even break compilation [1]).  Let's fix the
ones worth fixing, and for the others, let's tell clippy to ignore
them.

[1] https://github.com/rust-lang/rust-clippy/issues/3807