### PR TITLE
Fix attribution of `date.rs`

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -176,6 +176,7 @@
    END OF TERMS AND CONDITIONS
 
    Copyright 2019 Yoshua Wuyts
+   Copyright 2016-2018 Michael Tilli (Pyfisch) & `httpdate` contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2019 Yoshua Wuyts
+Copyright (c) 2016-2018 Michael Tilli (Pyfisch) & `httpdate` contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
In commit f7270411efdd0011359deac82a2e224629e7f671, we copied our date
implementation from the `httpdate` project [1] (#6, #19).  However,
this was done without proper attribution and preservation of copyright
notices.  Let's fix this.

[1] https://github.com/pyfisch/httpdate