### PR TITLE
add test for response with newlines instead of \r\n

### DIFF
--- a/src/client/decode.rs
+++ b/src/client/decode.rs
@@ -44,6 +44,9 @@ where
         if idx >= 3 && &buf[idx - 3..=idx] == [CR, LF, CR, LF] {
             break;
         }
+        if idx >= 1 && &buf[idx - 1..=idx] == [LF, LF] {
+            break;
+        }
     }
 
     // Convert our header buf into an httparse instance, and validate.

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -47,3 +47,23 @@ async fn test_multiple_header_values_for_same_header_name() {
 
     pretty_assertions::assert_eq!(res.header(&headers::SET_COOKIE).unwrap().len(), 2);
 }
+
+#[async_std::test]
+async fn test_response_newlines() {
+    let response_fixture = File::open(fixture_path("fixtures/response-newlines.txt"))
+        .await
+        .unwrap();
+
+    let res = client::decode(response_fixture).await.unwrap();
+
+    pretty_assertions::assert_eq!(
+        res.header(&headers::CONTENT_LENGTH)
+            .unwrap()
+            .last()
+            .unwrap()
+            .as_str()
+            .parse::<usize>()
+            .unwrap(),
+        78
+    );
+}

--- a/tests/fixtures/response-newlines.txt
+++ b/tests/fixtures/response-newlines.txt
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+content-length: 78
+date: {DATE}
+content-type: text/plain; charset=utf-8
+
+http specifies headers are separated with \r\n but many servers don't do that


### PR DESCRIPTION
While the HTTP standard specifies that the status-line and header-fields
should be terminated with a CRLF (\r\n), many implementations on the
internet would wrongly output only LF (\n). This is even recognized in the
RFC which  suggests that a LF may be recognized as a line terminator.

https://tools.ietf.org/html/rfc7230#section-3.5
>   Although the line terminator for the start-line and header fields is
>   the sequence CRLF, a recipient MAY recognize a single LF as a line
>   terminator and ignore any preceding CR.

This commit introduces a test for a response with only LF newlines.