### PR TITLE
Don't add the Host header if it already exists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 url = "2.1.0"
 httparse = "1.3.3"
 async-std = { version = "1.5.0", features = ["unstable"] }
-http-types = "1.0.0"
+http-types = "1.2.0"
 pin-project-lite = "0.1.1"
 byte-pool = "0.2.1"
 lazy_static = "1.4.0"

--- a/src/client/encode.rs
+++ b/src/client/encode.rs
@@ -56,18 +56,20 @@ impl Encoder {
         log::trace!("> {}", &val);
         buf.write_all(val.as_bytes()).await?;
 
-        // Insert Host header
-        // Insert host
-        let host = req.url().host_str();
-        let host = host.ok_or_else(|| format_err!("Missing hostname"))?;
-        let val = if let Some(port) = req.url().port() {
-            format!("host: {}:{}\r\n", host, port)
-        } else {
-            format!("host: {}\r\n", host)
-        };
+        if req.header(&http_types::headers::HOST).is_none() {
+            // Insert Host header
+            // Insert host
+            let host = req.url().host_str();
+            let host = host.ok_or_else(|| format_err!("Missing hostname"))?;
+            let val = if let Some(port) = req.url().port() {
+                format!("host: {}:{}\r\n", host, port)
+            } else {
+                format!("host: {}\r\n", host)
+            };
 
-        log::trace!("> {}", &val);
-        buf.write_all(val.as_bytes()).await?;
+            log::trace!("> {}", &val);
+            buf.write_all(val.as_bytes()).await?;
+        }
 
         // Insert Proxy-Connection header when method is CONNECT
         if req.method() == Method::Connect {


### PR DESCRIPTION
the request can already contain a host header, either because it came
from the async_h1::accept, or because the user set it manually. In that
case don't add a second host header (the one based on `req.url()`).