### PR TITLE
no need to send date header in client

### DIFF
--- a/src/client/encode.rs
+++ b/src/client/encode.rs
@@ -6,8 +6,6 @@ use http_types::{Method, Request};
 
 use std::pin::Pin;
 
-use crate::date::fmt_http_date;
-
 /// An HTTP encoder.
 #[doc(hidden)]
 #[derive(Debug)]
@@ -88,11 +86,6 @@ impl Encoder {
             // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding
             //      https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer
         }
-
-        let date = fmt_http_date(std::time::SystemTime::now());
-        buf.write_all(b"date: ").await?;
-        buf.write_all(date.as_bytes()).await?;
-        buf.write_all(b"\r\n").await?;
 
         for (header, values) in req.iter() {
             for value in values.iter() {

--- a/tests/fixtures/request-add-date.txt
+++ b/tests/fixtures/request-add-date.txt
@@ -1,7 +1,6 @@
 POST / HTTP/1.1
 host: localhost:8080
 content-length: 5
-date: {DATE}
 content-type: text/plain; charset=utf-8
 
 hello

--- a/tests/fixtures/request-with-connect.txt
+++ b/tests/fixtures/request-with-connect.txt
@@ -2,5 +2,4 @@ CONNECT example.com:443 HTTP/1.1
 host: example.com
 proxy-connection: keep-alive
 content-length: 0
-date: {DATE}
 


### PR DESCRIPTION
The date header is optional for clients, but also seems to be
discouraged. It's so rare so maybe leave it to the user.

https://tools.ietf.org/html/rfc7231#section-7.1.1.2
> A user agent MAY send a Date…

The older RFC https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.18
> Clients SHOULD only send a Date header field in messages that include an entity-body, as in the case of the PUT and POST requests, and even then it is optional. A client without a clock MUST NOT send a Date header field in a request.