### PR TITLE
Don't add the Date header in a response if it already exists

### DIFF
--- a/src/server/encode.rs
+++ b/src/server/encode.rs
@@ -84,8 +84,10 @@ impl Encoder {
             )?;
         }
 
-        let date = fmt_http_date(std::time::SystemTime::now());
-        std::io::Write::write_fmt(&mut self.head, format_args!("date: {}\r\n", date))?;
+        if self.res.header(&http_types::headers::DATE).is_none() {
+            let date = fmt_http_date(std::time::SystemTime::now());
+            std::io::Write::write_fmt(&mut self.head, format_args!("date: {}\r\n", date))?;
+        }
 
         for (header, values) in self.res.iter() {
             for value in values.iter() {


### PR DESCRIPTION
the response can already contain a date header, either because it came
from the async_h1::client::connect, or because the user set it manually.
In that case don't add a second date header.