### PR TITLE
Server encoder state machine

### DIFF
--- a/src/chunked/encoder.rs
+++ b/src/chunked/encoder.rs
@@ -12,7 +12,7 @@ const CRLF_LEN: usize = 2;
 /// The encoder state.
 #[derive(Debug)]
 enum State {
-    /// Initing state.
+    /// Starting state.
     Init,
     /// Streaming out chunks.
     EncodeChunks,

--- a/src/chunked/encoder.rs
+++ b/src/chunked/encoder.rs
@@ -72,13 +72,13 @@ impl ChunkedEncoder {
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
         self.bytes_written = 0;
-        let res = self.exec(res, cx, buf);
+        let res = self.dispatch(res, cx, buf);
         log::trace!("ChunkedEncoder {} bytes written", self.bytes_written);
         res
     }
 
     /// Execute the right method for the current state.
-    fn exec(
+    fn dispatch(
         &mut self,
         res: &mut Response,
         cx: &mut Context<'_>,
@@ -118,7 +118,7 @@ impl ChunkedEncoder {
         }
 
         self.state = state;
-        self.exec(res, cx, buf)
+        self.dispatch(res, cx, buf)
     }
 
     /// Stream out data using chunked encoding.

--- a/src/server/encode.rs
+++ b/src/server/encode.rs
@@ -60,7 +60,7 @@ impl Read for Encoder {
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
         self.bytes_written = 0;
-        let res = self.exec(cx, buf);
+        let res = self.dispatch(cx, buf);
         log::trace!("ServerEncoder {} bytes written", self.bytes_written);
         res
     }
@@ -103,11 +103,11 @@ impl Encoder {
         }
 
         self.state = state;
-        self.exec(cx, buf)
+        self.dispatch(cx, buf)
     }
 
     /// Execute the right method for the current state.
-    fn exec(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+    fn dispatch(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
         match self.state {
             State::Start => self.set_state(State::ComputeHead, cx, buf),
             State::ComputeHead => self.compute_head(cx, buf),

--- a/src/server/encode.rs
+++ b/src/server/encode.rs
@@ -165,12 +165,10 @@ impl Encoder {
                 Some(body_len) => {
                     self.body_len = body_len;
                     self.state = State::EncodeFixedBody;
-                    log::trace!("Server response encoding: fixed length body");
                     return self.encode_fixed_body(cx, buf);
                 }
                 None => {
                     self.state = State::EncodeChunkedBody;
-                    log::trace!("Server response encoding: chunked body");
                     return self.encode_chunked_body(cx, buf);
                 }
             };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -73,7 +73,7 @@ where
 
         // Pass the request to the endpoint and encode the response.
         let res = endpoint(req).await?;
-        let mut encoder = Encoder::encode(res);
+        let mut encoder = Encoder::new(res);
 
         // Stream the response to the writer.
         io::copy(&mut encoder, &mut io).await?;


### PR DESCRIPTION
This reworks the server encoder to similar to the chunked encoder. The main benefit of this is that we now use an internal state machine which logs each state transition and how many bytes have been written, making it possible to debug using `log` instead of having to manually insert debug statements.

Also gave some variables and functions the same name so that the two encoders are comparable. And documented what each state does. Thanks!

__edit:__ this was done in response to seeing a report in https://github.com/http-rs/tide/issues/458 -- I wish we could ask the user there to log out the full intermediate parsing steps so that we can look whether we can spot anything strange from the outset.