### PR TITLE
filter out content-length and transfer-encoding from pass Response

### DIFF
--- a/src/server/encode.rs
+++ b/src/server/encode.rs
@@ -89,7 +89,12 @@ impl Encoder {
             std::io::Write::write_fmt(&mut self.head, format_args!("date: {}\r\n", date))?;
         }
 
-        for (header, values) in self.res.iter() {
+        let iter = self
+            .res
+            .iter()
+            .filter(|(h, _)| h != &&http_types::headers::CONTENT_LENGTH)
+            .filter(|(h, _)| h != &&http_types::headers::TRANSFER_ENCODING);
+        for (header, values) in iter {
             for value in values.iter() {
                 std::io::Write::write_fmt(
                     &mut self.head,


### PR DESCRIPTION
the Response (res) in server::encode::Encoder might already have
content-length or transfer-encoding, which even might be wrong (if set
manually). Filter them out when iterating the response headers, proper
values were anyway written to the head before.