### PR TITLE
set request url host from host header

### DIFF
--- a/tests/fixtures/request-with-host.txt
+++ b/tests/fixtures/request-with-host.txt
@@ -1,0 +1,4 @@
+GET /pub/WWW/TheProject.html HTTP/1.1
+Host: www.w3.org
+Content-Length: 0
+

--- a/tests/fixtures/response-with-host.txt
+++ b/tests/fixtures/response-with-host.txt
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+content-length: 41
+date: {DATE}
+content-type: text/plain; charset=utf-8
+
+http://www.w3.org/pub/WWW/TheProject.html

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -26,6 +26,26 @@ async fn test_basic_request() {
 }
 
 #[async_std::test]
+async fn test_host() {
+    let case = TestCase::new_server(
+        "fixtures/request-with-host.txt",
+        "fixtures/response-with-host.txt",
+    )
+    .await;
+    let addr = "http://127.0.0.1:8000";
+
+    async_h1::accept(addr, case.clone(), |req| async move {
+        let mut res = Response::new(StatusCode::Ok);
+        res.set_body(req.url().as_str());
+        Ok(res)
+    })
+    .await
+    .unwrap();
+
+    case.assert().await;
+}
+
+#[async_std::test]
 async fn test_chunked_basic() {
     let case = TestCase::new_server(
         "fixtures/request-chunked-basic.txt",


### PR DESCRIPTION
With this change, the request.url() represents what the client is actually requesting.

### Example 

Scenario: An async-h1-based server is bound to `127.0.0.1:3000` and proxied through a load balancer that's externally visible at `https://vhost.example.com`. Prior to this commit, a request to `/index.html` would have a request.url() of `http://127.0.0.1:3000/index.html`. After this change, the `request.url()` would be `http://vhost.example.com/index.html`.

### Code Issues

It is awkward that we have to parse a url and then substitute the host information, but this due to the fact that Request::new takes a url, and header parsing currently requires a constructed request. To address this, the Request constructor should not require a Url, but that can be done as a later refactor.

This PR does not set the scheme from proxy request headers, but doing so in the future would fully reconstruct the client-side request url.

### Rationale

This change will be essential when tide supports filesystem sockets (unix domain socket / windows named pipes), which don't actually have a canonical equivalent of `127.0.0.1:3000` in the above example. If the owner of a http-types request needs to know the locally bound address (`127.0.0.1:3000`), they can ask the request for `local_addr()`.

### Alternative approaches

Using a path-only URI representation

