### PR TITLE
No addr needed for accept

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -14,9 +14,8 @@ async fn main() -> http_types::Result<()> {
     let mut incoming = listener.incoming();
     while let Some(stream) = incoming.next().await {
         let stream = stream?;
-        let addr = addr.clone();
         task::spawn(async {
-            if let Err(err) = accept(addr, stream).await {
+            if let Err(err) = accept(stream).await {
                 eprintln!("{}", err);
             }
         });
@@ -25,9 +24,9 @@ async fn main() -> http_types::Result<()> {
 }
 
 // Take a TCP stream, and convert it into sequential HTTP request / response pairs.
-async fn accept(addr: String, stream: TcpStream) -> http_types::Result<()> {
+async fn accept(stream: TcpStream) -> http_types::Result<()> {
     println!("starting new connection from {}", stream.peer_addr()?);
-    async_h1::accept(&addr, stream.clone(), |_req| async move {
+    async_h1::accept(stream.clone(), |_req| async move {
         let mut res = Response::new(StatusCode::Ok);
         res.insert_header("Content-Type", "text/plain")?;
         res.set_body("Hello world");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,8 @@
 //!     let mut incoming = listener.incoming();
 //!     while let Some(stream) = incoming.next().await {
 //!         let stream = stream?;
-//!         let addr = addr.clone();
 //!         task::spawn(async {
-//!             if let Err(err) = accept(addr, stream).await {
+//!             if let Err(err) = accept(stream).await {
 //!                 eprintln!("{}", err);
 //!             }
 //!         });
@@ -78,9 +77,9 @@
 //! }
 //!
 //! // Take a TCP stream, and convert it into sequential HTTP request / response pairs.
-//! async fn accept(addr: String, stream: TcpStream) -> http_types::Result<()> {
+//! async fn accept(stream: TcpStream) -> http_types::Result<()> {
 //!     println!("starting new connection from {}", stream.peer_addr()?);
-//!     async_h1::accept(&addr, stream.clone(), |_req| async move {
+//!     async_h1::accept(stream.clone(), |_req| async move {
 //!         let mut res = Response::new(StatusCode::Ok);
 //!         res.insert_header("Content-Type", "text/plain")?;
 //!         res.set_body("Hello");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -31,20 +31,19 @@ impl Default for ServerOptions {
 /// Accept a new incoming HTTP/1.1 connection.
 ///
 /// Supports `KeepAlive` requests by default.
-pub async fn accept<RW, F, Fut>(addr: &str, io: RW, endpoint: F) -> http_types::Result<()>
+pub async fn accept<RW, F, Fut>(io: RW, endpoint: F) -> http_types::Result<()>
 where
     RW: Read + Write + Clone + Send + Sync + Unpin + 'static,
     F: Fn(Request) -> Fut,
     Fut: Future<Output = http_types::Result<Response>>,
 {
-    accept_with_opts(addr, io, endpoint, Default::default()).await
+    accept_with_opts(io, endpoint, Default::default()).await
 }
 
 /// Accept a new incoming HTTP/1.1 connection.
 ///
 /// Supports `KeepAlive` requests by default.
 pub async fn accept_with_opts<RW, F, Fut>(
-    addr: &str,
     mut io: RW,
     endpoint: F,
     opts: ServerOptions,
@@ -56,7 +55,7 @@ where
 {
     loop {
         // Decode a new request, timing out if this takes longer than the timeout duration.
-        let fut = decode(addr, io.clone());
+        let fut = decode(io.clone());
 
         let req = if let Some(timeout_duration) = opts.headers_timeout {
             match timeout(timeout_duration, fut).await {

--- a/tests/fixtures/request-unexpected-eof.txt
+++ b/tests/fixtures/request-unexpected-eof.txt
@@ -1,4 +1,5 @@
 POST / HTTP/1.1
+host: example.com
 content-type: text/plain
 content-length: 11
 

--- a/tests/fixtures/request-with-host.txt
+++ b/tests/fixtures/request-with-host.txt
@@ -1,0 +1,4 @@
+GET /pub/WWW/TheProject.html HTTP/1.1
+Host: www.w3.org
+Content-Length: 0
+

--- a/tests/fixtures/response-with-host.txt
+++ b/tests/fixtures/response-with-host.txt
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+content-length: 41
+date: {DATE}
+content-type: text/plain; charset=utf-8
+
+http://www.w3.org/pub/WWW/TheProject.html

--- a/tests/server-chunked-encode-large.rs
+++ b/tests/server-chunked-encode-large.rs
@@ -145,7 +145,7 @@ const RESPONSE: &'static str = concat![
 #[async_std::test]
 async fn server_chunked_large() {
     let case = TestCase::new(REQUEST, "").await;
-    async_h1::accept("http://example.com", case.clone(), |_| async {
+    async_h1::accept(case.clone(), |_| async {
         let mut res = Response::new(StatusCode::Ok);
         let body = Cursor::new(TEXT.to_owned());
         res.set_body(Body::from_reader(body, None));

--- a/tests/server-chunked-encode-small.rs
+++ b/tests/server-chunked-encode-small.rs
@@ -41,7 +41,7 @@ const RESPONSE: &'static str = concat![
 #[async_std::test]
 async fn server_chunked_large() {
     let case = TestCase::new(REQUEST, "").await;
-    async_h1::accept("http://example.com", case.clone(), |_| async {
+    async_h1::accept(case.clone(), |_| async {
         let mut res = Response::new(StatusCode::Ok);
         let body = Cursor::new(TEXT.to_owned());
         res.set_body(Body::from_reader(body, None));

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -26,6 +26,26 @@ async fn test_basic_request() {
 }
 
 #[async_std::test]
+async fn test_host() {
+    let case = TestCase::new_server(
+        "fixtures/request-with-host.txt",
+        "fixtures/response-with-host.txt",
+    )
+    .await;
+    let addr = "http://127.0.0.1:8000";
+
+    async_h1::accept(addr, case.clone(), |req| async move {
+        let mut res = Response::new(StatusCode::Ok);
+        res.set_body(req.url().as_str());
+        Ok(res)
+    })
+    .await
+    .unwrap();
+
+    case.assert().await;
+}
+
+#[async_std::test]
 async fn test_chunked_basic() {
     let case = TestCase::new_server(
         "fixtures/request-chunked-basic.txt",

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -12,9 +12,8 @@ async fn test_basic_request() {
         "fixtures/response-add-date.txt",
     )
     .await;
-    let addr = "http://example.com";
 
-    async_h1::accept(addr, case.clone(), |_req| async {
+    async_h1::accept(case.clone(), |_req| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body("");
         Ok(res)
@@ -32,9 +31,8 @@ async fn test_host() {
         "fixtures/response-with-host.txt",
     )
     .await;
-    let addr = "http://127.0.0.1:8000";
 
-    async_h1::accept(addr, case.clone(), |req| async move {
+    async_h1::accept(case.clone(), |req| async move {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(req.url().as_str());
         Ok(res)
@@ -52,9 +50,8 @@ async fn test_chunked_basic() {
         "fixtures/response-chunked-basic.txt",
     )
     .await;
-    let addr = "http://example.com";
 
-    async_h1::accept(addr, case.clone(), |_req| async {
+    async_h1::accept(case.clone(), |_req| async {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(Body::from_reader(
             Cursor::new(b"Mozilla")
@@ -79,8 +76,7 @@ async fn test_chunked_echo() {
     )
     .await;
 
-    let addr = "http://example.com";
-    async_h1::accept(addr, case.clone(), |req| async {
+    async_h1::accept(case.clone(), |req| async {
         let ct = req.content_type();
         let body: Body = req.into();
 
@@ -106,9 +102,8 @@ async fn test_unexpected_eof() {
         "fixtures/response-unexpected-eof.txt",
     )
     .await;
-    let addr = "http://example.com";
 
-    async_h1::accept(addr, case.clone(), |req| async {
+    async_h1::accept(case.clone(), |req| async {
         let mut res = Response::new(StatusCode::Ok);
         let ct = req.content_type();
         let body: Body = req.into();
@@ -132,9 +127,8 @@ async fn test_invalid_trailer() {
         "fixtures/response-invalid-trailer.txt",
     )
     .await;
-    let addr = "http://example.com";
 
-    async_h1::accept(addr, case.clone(), |req| async {
+    async_h1::accept(case.clone(), |req| async {
         let mut res = Response::new(StatusCode::Ok);
         let ct = req.content_type();
         let body: Body = req.into();


### PR DESCRIPTION
because the host header is mandatory for http/1.1, the addr argument to accept is unnecessary and unused. this builds upon #106