### PR TITLE
Make decode fallable

### DIFF
--- a/src/client/decode.rs
+++ b/src/client/decode.rs
@@ -16,7 +16,6 @@ const CR: u8 = b'\r';
 const LF: u8 = b'\n';
 
 /// Decode an HTTP response on the client.
-#[doc(hidden)]
 pub async fn decode<R>(reader: R) -> http_types::Result<Response>
 where
     R: Read + Unpin + Send + Sync + 'static,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,7 @@ pub use decode::decode;
 pub use encode::Encoder;
 
 /// Opens an HTTP/1.1 connection to a remote host.
-pub async fn connect<RW>(mut stream: RW, req: Request) -> http_types::Result<Response>
+pub async fn connect<RW>(mut stream: RW, req: Request) -> http_types::Result<Option<Response>>
 where
     RW: Read + Write + Send + Sync + Unpin + 'static,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,8 @@ const MAX_HEAD_LENGTH: usize = 8 * 1024;
 
 mod chunked;
 mod date;
-mod server;
+pub mod server;
 
-#[doc(hidden)]
 pub mod client;
 
 pub use client::connect;

--- a/src/server/decode.rs
+++ b/src/server/decode.rs
@@ -118,9 +118,7 @@ fn set_url_and_port_from_host_header(req: &mut Request) -> http_types::Result<()
 
     if !req.url().cannot_be_a_base() {
         if let Some(colon) = host.find(":") {
-            println!("AAAA");
             req.url_mut().set_host(Some(&host[0..colon]))?;
-            println!("AAAA");
             req.url_mut()
                 .set_port(host[colon + 1..].parse().ok())
                 .unwrap();

--- a/src/server/decode.rs
+++ b/src/server/decode.rs
@@ -17,7 +17,7 @@ const LF: u8 = b'\n';
 const HTTP_1_1_VERSION: u8 = 1;
 
 /// Decode an HTTP request on the server.
-pub(crate) async fn decode<IO>(mut io: IO) -> http_types::Result<Option<Request>>
+pub async fn decode<IO>(mut io: IO) -> http_types::Result<Option<Request>>
 where
     IO: Read + Write + Clone + Send + Sync + Unpin + 'static,
 {
@@ -116,13 +116,17 @@ fn set_url_and_port_from_host_header(req: &mut Request) -> http_types::Result<()
         .ok_or_else(|| format_err!("Mandatory Host header missing"))? //  https://tools.ietf.org/html/rfc7230#section-5.4
         .to_string();
 
-    if let Some(colon) = host.find(":") {
-        req.url_mut().set_host(Some(&host[0..colon]))?;
-        req.url_mut()
-            .set_port(host[colon + 1..].parse().ok())
-            .unwrap();
-    } else {
-        req.url_mut().set_host(Some(&host))?;
+    if !req.url().cannot_be_a_base() {
+        if let Some(colon) = host.find(":") {
+            println!("AAAA");
+            req.url_mut().set_host(Some(&host[0..colon]))?;
+            println!("AAAA");
+            req.url_mut()
+                .set_port(host[colon + 1..].parse().ok())
+                .unwrap();
+        } else {
+            req.url_mut().set_host(Some(&host))?;
+        }
     }
 
     Ok(())

--- a/src/server/encode.rs
+++ b/src/server/encode.rs
@@ -15,7 +15,7 @@ use crate::date::fmt_http_date;
 ///
 /// This is returned from [`encode`].
 #[derive(Debug)]
-pub(crate) struct Encoder {
+pub struct Encoder {
     /// The current level of recursion the encoder is in.
     depth: u16,
     /// HTTP headers to be sent.
@@ -69,7 +69,7 @@ impl Read for Encoder {
 
 impl Encoder {
     /// Create a new instance of Encoder.
-    pub(crate) fn new(res: Response) -> Self {
+    pub fn new(res: Response) -> Self {
         Self {
             res,
             depth: 0,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,8 +10,8 @@ use http_types::{Request, Response};
 mod decode;
 mod encode;
 
-use decode::decode;
-use encode::Encoder;
+pub use decode::decode;
+pub use encode::Encoder;
 
 /// Configure the server.
 #[derive(Debug, Clone)]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -19,7 +19,7 @@ async fn test_encode_request_add_date() {
     let mut req = Request::new(Method::Post, url);
     req.set_body("hello");
 
-    let res = client::connect(case.clone(), req).await.unwrap();
+    let res = client::connect(case.clone(), req).await.unwrap().unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
 
     case.assert().await;
@@ -31,7 +31,7 @@ async fn test_response_no_date() {
         .await
         .unwrap();
 
-    let res = client::decode(response_fixture).await.unwrap();
+    let res = client::decode(response_fixture).await.unwrap().unwrap();
 
     pretty_assertions::assert_eq!(res.header(&headers::DATE).is_some(), true);
 }
@@ -42,7 +42,7 @@ async fn test_multiple_header_values_for_same_header_name() {
         .await
         .unwrap();
 
-    let res = client::decode(response_fixture).await.unwrap();
+    let res = client::decode(response_fixture).await.unwrap().unwrap();
 
     pretty_assertions::assert_eq!(res.header(&headers::SET_COOKIE).unwrap().iter().count(), 2);
 }
@@ -53,7 +53,7 @@ async fn test_response_newlines() {
         .await
         .unwrap();
 
-    let res = client::decode(response_fixture).await.unwrap();
+    let res = client::decode(response_fixture).await.unwrap().unwrap();
 
     pretty_assertions::assert_eq!(
         res[headers::CONTENT_LENGTH]
@@ -75,7 +75,7 @@ async fn test_encode_request_with_connect() {
     let url = Url::parse("https://example.com:443").unwrap();
     let req = Request::new(Method::Connect, url);
 
-    let res = client::connect(case.clone(), req).await.unwrap();
+    let res = client::connect(case.clone(), req).await.unwrap().unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
 
     case.assert().await;


### PR DESCRIPTION
I was getting a panic in the case when the response to a request was not returned by the server, so I think the decode function should be fallible. 