### PR TITLE
do not send body content in reply to HEAD requests

### DIFF
--- a/src/server/encode.rs
+++ b/src/server/encode.rs
@@ -6,7 +6,7 @@ use async_std::io;
 use async_std::io::prelude::*;
 use async_std::task::{Context, Poll};
 use http_types::headers::{CONTENT_LENGTH, DATE, TRANSFER_ENCODING};
-use http_types::Response;
+use http_types::{Method, Response};
 
 use crate::chunked::ChunkedEncoder;
 use crate::date::fmt_http_date;
@@ -36,6 +36,8 @@ pub(crate) struct Encoder {
     body_bytes_written: usize,
     /// An encoder for chunked encoding.
     chunked: ChunkedEncoder,
+    /// the http method that this response is in reply to
+    method: Method,
 }
 
 #[derive(Debug)]
@@ -69,7 +71,7 @@ impl Read for Encoder {
 
 impl Encoder {
     /// Create a new instance of Encoder.
-    pub(crate) fn new(res: Response) -> Self {
+    pub(crate) fn new(res: Response, method: Method) -> Self {
         Self {
             res,
             depth: 0,
@@ -80,6 +82,7 @@ impl Encoder {
             body_len: 0,
             body_bytes_written: 0,
             chunked: ChunkedEncoder::new(),
+            method,
         }
     }
 
@@ -97,7 +100,7 @@ impl Encoder {
         match self.state {
             Start => assert!(matches!(state, ComputeHead)),
             ComputeHead => assert!(matches!(state, EncodeHead)),
-            EncodeHead => assert!(matches!(state, EncodeChunkedBody | EncodeFixedBody)),
+            EncodeHead => assert!(matches!(state, EncodeChunkedBody | EncodeFixedBody | End)),
             EncodeFixedBody => assert!(matches!(state, End)),
             EncodeChunkedBody => assert!(matches!(state, End)),
             End => panic!("No state transitions allowed after the ServerEncoder has ended"),
@@ -176,14 +179,20 @@ impl Encoder {
         // If we've read the total length of the head we're done
         // reading the head and can transition to reading the body
         if self.head_bytes_written == head_len {
-            // The response length lets us know if we are encoding
-            // our body in chunks or not
-            match self.res.len() {
-                Some(body_len) => {
-                    self.body_len = body_len;
-                    self.dispatch(State::EncodeFixedBody, cx, buf)
+            if self.method == Method::Head {
+                // If we are responding to a HEAD request, we MUST NOT send
+                // body content
+                self.dispatch(State::End, cx, buf)
+            } else {
+                // The response length lets us know if we are encoding
+                // our body in chunks or not
+                match self.res.len() {
+                    Some(body_len) => {
+                        self.body_len = body_len;
+                        self.dispatch(State::EncodeFixedBody, cx, buf)
+                    }
+                    None => self.dispatch(State::EncodeChunkedBody, cx, buf),
                 }
-                None => self.dispatch(State::EncodeChunkedBody, cx, buf),
             }
         } else {
             // If we haven't read the entire header it means `buf` isn't

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -70,9 +70,11 @@ where
             }
         };
 
+        let method = req.method();
         // Pass the request to the endpoint and encode the response.
         let res = endpoint(req).await?;
-        let mut encoder = Encoder::new(res);
+
+        let mut encoder = Encoder::new(res, method);
 
         // Stream the response to the writer.
         io::copy(&mut encoder, &mut io).await?;

--- a/tests/fixtures/head_request.txt
+++ b/tests/fixtures/head_request.txt
@@ -1,0 +1,4 @@
+HEAD / HTTP/1.1
+host: example.com
+user-agent: curl/7.54.0
+

--- a/tests/fixtures/head_response.txt
+++ b/tests/fixtures/head_response.txt
@@ -1,0 +1,5 @@
+HTTP/1.1 200 OK
+content-length: 5
+date: {DATE}
+content-type: text/plain;charset=utf-8
+

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -144,3 +144,14 @@ async fn test_invalid_trailer() {
 
     assert!(case.read_result().await.is_empty());
 }
+#[async_std::test]
+async fn empty_body_for_head_requests() {
+    let case =
+        TestCase::new_server("fixtures/head_request.txt", "fixtures/head_response.txt").await;
+
+    async_h1::accept(case.clone(), |_| async { Ok("hello".into()) })
+        .await
+        .unwrap();
+
+    case.assert().await;
+}


### PR DESCRIPTION
Refs http-rs/tide#623, closes #125 

HTTP HEAD responses [MUST NOT](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4) include response body content, but async-h1 does not currently support the ability to omit the response body and still send a content-length header.

Attempts to close this at the http-types layer left async-h1 hanging indefinitely because async-h1 uses the same notion of body length for the header and the actual response body sending. In order to address this at the async-h1 level, the encoder needs to know the request method.  No public API as of this commit is changed by this spec-conformance bugfix.