### PR TITLE
Client must not send fragment of URL

### DIFF
--- a/src/client/encode.rs
+++ b/src/client/encode.rs
@@ -30,10 +30,6 @@ impl Encoder {
         let mut buf: Vec<u8> = vec![];
 
         let mut url = req.url().path().to_owned();
-        if let Some(fragment) = req.url().fragment() {
-            url.push('#');
-            url.push_str(fragment);
-        }
         if let Some(query) = req.url().query() {
             url.push('?');
             url.push_str(query);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -80,3 +80,21 @@ async fn test_encode_request_with_connect() {
 
     case.assert().await;
 }
+
+// The fragment of an URL is not send to the server, see RFC7230 and RFC3986.
+#[async_std::test]
+async fn test_encode_request_with_fragment() {
+    let case = TestCase::new_client(
+        "fixtures/request-with-fragment.txt",
+        "fixtures/response-with-host.txt",
+    )
+    .await;
+
+    let url = Url::parse("http://example.com/path?query#fragment").unwrap();
+    let req = Request::new(Method::Get, url);
+
+    let res = client::connect(case.clone(), req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::Ok);
+
+    case.assert().await;
+}

--- a/tests/fixtures/request-with-fragment.txt
+++ b/tests/fixtures/request-with-fragment.txt
@@ -1,0 +1,4 @@
+GET /path?query HTTP/1.1
+host: example.com
+content-length: 0
+


### PR DESCRIPTION
The fragment part of an URL is purely for the client and is not expected to be sent to the client.

Referring [RFC7230](https://tools.ietf.org/html/rfc7230#section-5.1), and [RFC3986](https://tools.ietf.org/html/rfc3986#section-3.5). Excerpt below:

> 5.1.  Identifying a Target Resource
> [...] The target URI excludes the reference's fragment component, if any,
> since fragment identifiers are reserved for client-side processing
> ([RFC3986], Section 3.5).

> 3.5.  Fragment
> [...] As such, the fragment identifier is not used in the
> scheme-specific processing of a URI; instead, the fragment identifier is
> separated from the rest of the URI prior to a dereference, and thus the
> identifying information within the fragment itself is dereferenced solely
> by the user agent, regardless of the URI scheme.

