### PR TITLE
Main branch renamed to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
       Releases
     </a>
     <span> | </span>
-    <a href="https://github.com/http-rs/async-h1/blob/master.github/CONTRIBUTING.md">
+    <a href="https://github.com/http-rs/async-h1/blob/main/.github/CONTRIBUTING.md">
       Contributing
     </a>
   </h3>
@@ -66,7 +66,7 @@ look at some of these issues:
 - [Issues labeled "good first issue"][good-first-issue]
 - [Issues labeled "help wanted"][help-wanted]
 
-[contributing]: https://github.com/http-rs/async-h1/blob/master/.github/CONTRIBUTING.md
+[contributing]: https://github.com/http-rs/async-h1/blob/main/.github/CONTRIBUTING.md
 [good-first-issue]: https://github.com/http-rs/async-h1/labels/good%20first%20issue
 [help-wanted]: https://github.com/http-rs/async-h1/labels/help%20wanted
 


### PR DESCRIPTION
Per https://github.com/http-rs/surf/issues/211, all the main branch names in the http-rs org have been changed to `main`. This PR updates the references from the old name and hopefully also serves as a notification for contributors! If there is any more fallout, please @ me and I'll do my best to deal with it.