### PR TITLE
async-std/unstable not needed for async-h1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 httparse = "1.3.3"
-async-std = { version = "1.6.0", features = ["unstable"] }
+async-std = { version = "1.6.0" }
 http-types = "2.0.0"
 pin-project-lite = "0.1.1"
 byte-pool = "0.2.1"
@@ -23,6 +23,6 @@ log = "0.4"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
-async-std = { version = "1.4.0", features = ["unstable", "attributes"] }
+async-std = { version = "1.4.0", features = ["attributes"] }
 tempfile = "3.1.0"
 async-test = "1.0.0"


### PR DESCRIPTION
closes #136 
note: this is mutually exclusive with #139, which uses a channel, so probably this can be closed