### PR TITLE
don't send 100-continue until the body has been read from

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ log = "0.4"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
-async-std = { version = "1.4.0", features = ["unstable", "attributes"] }
+async-std = { version = "1.6.2", features = ["unstable", "attributes"] }
 tempfile = "3.1.0"
 async-test = "1.0.0"
-duplexify = { version = "1.1.0", git = "https://github.com/jbr/duplexify", branch = "impl-clone-when-reader-and-writer-are-clone" }
+duplexify = "1.2.1"
 async-dup = "1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ pretty_assertions = "0.6.1"
 async-std = { version = "1.4.0", features = ["unstable", "attributes"] }
 tempfile = "3.1.0"
 async-test = "1.0.0"
+duplexify = { version = "1.1.0", git = "https://github.com/jbr/duplexify", branch = "impl-clone-when-reader-and-writer-are-clone" }
+async-dup = "1.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ const MAX_HEAD_LENGTH: usize = 8 * 1024;
 
 mod chunked;
 mod date;
+mod read_notifier;
 
 pub mod client;
 pub mod server;

--- a/src/read_notifier.rs
+++ b/src/read_notifier.rs
@@ -1,0 +1,65 @@
+use std::{
+    fmt, io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use async_std::{
+    io::{BufRead, Read},
+    sync::Sender,
+};
+
+pin_project_lite::pin_project! {
+    pub(crate) struct ReadNotifier<B>{
+        #[pin]
+        reader: B,
+        sender: Sender<()>,
+        read: bool
+    }
+}
+
+impl<B> fmt::Debug for ReadNotifier<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadNotifier")
+            .field("read", &self.read)
+            .finish()
+    }
+}
+
+impl<B: BufRead> ReadNotifier<B> {
+    pub(crate) fn new(reader: B, sender: Sender<()>) -> Self {
+        Self {
+            reader,
+            sender,
+            read: false,
+        }
+    }
+}
+
+impl<B: BufRead> BufRead for ReadNotifier<B> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        self.project().reader.poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.project().reader.consume(amt)
+    }
+}
+
+impl<B: Read> Read for ReadNotifier<B> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.project();
+
+        if !*this.read {
+            if let Ok(()) = this.sender.try_send(()) {
+                *this.read = true;
+            };
+        }
+
+        this.reader.poll_read(cx, buf)
+    }
+}

--- a/src/read_notifier.rs
+++ b/src/read_notifier.rs
@@ -1,13 +1,9 @@
-use std::{
-    fmt, io,
-    pin::Pin,
-    task::{Context, Poll},
-};
+use std::fmt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use async_std::{
-    io::{BufRead, Read},
-    sync::Sender,
-};
+use async_std::io::{self, BufRead, Read};
+use async_std::sync::Sender;
 
 pin_project_lite::pin_project! {
     pub(crate) struct ReadNotifier<B>{

--- a/src/server/decode.rs
+++ b/src/server/decode.rs
@@ -102,10 +102,8 @@ where
     if let Some(encoding) = transfer_encoding {
         if encoding.last().as_str() == "chunked" {
             let trailer_sender = req.send_trailers();
-            let reader = ReadNotifier::new(
-                BufReader::new(ChunkedDecoder::new(reader, trailer_sender)),
-                sender,
-            );
+            let reader = BufReader::new(ChunkedDecoder::new(reader, trailer_sender));
+            let reader = ReadNotifier::new(reader, sender);
             req.set_body(Body::from_reader(reader, None));
             return Ok(Some(req));
         }

--- a/tests/continue.rs
+++ b/tests/continue.rs
@@ -1,0 +1,75 @@
+use async_dup::{Arc, Mutex};
+use async_std::io::{Cursor, SeekFrom};
+use async_std::{prelude::*, task};
+use duplexify::Duplex;
+use http_types::Result;
+use std::time::Duration;
+
+const REQUEST_WITH_EXPECT: &[u8] = b"POST / HTTP/1.1\r\n\
+Host: example.com\r\n\
+Content-Length: 10\r\n\
+Expect: 100-continue\r\n\r\n";
+
+const SLEEP_DURATION: Duration = std::time::Duration::from_millis(100);
+#[async_std::test]
+async fn test_with_expect_when_reading_body() -> Result<()> {
+    let client_str: Vec<u8> = REQUEST_WITH_EXPECT.to_vec();
+    let server_str: Vec<u8> = vec![];
+
+    let mut client = Arc::new(Mutex::new(Cursor::new(client_str)));
+    let server = Arc::new(Mutex::new(Cursor::new(server_str)));
+
+    let mut request = async_h1::server::decode(Duplex::new(client.clone(), server.clone()))
+        .await?
+        .unwrap();
+
+    task::sleep(SLEEP_DURATION).await; //prove we're not just testing before we've written
+
+    {
+        let lock = server.lock();
+        assert_eq!("", std::str::from_utf8(lock.get_ref())?); //we haven't written yet
+    };
+
+    let mut buf = vec![0u8; 1];
+    let bytes = request.read(&mut buf).await?; //this triggers the 100-continue even though there's nothing to read yet
+    assert_eq!(bytes, 0); // normally we'd actually be waiting for the end of the buffer, but this lets us test this sequentially
+
+    task::sleep(SLEEP_DURATION).await; // just long enough to wait for the channel and io
+
+    {
+        let lock = server.lock();
+        assert_eq!(
+            "HTTP/1.1 100 Continue\r\n\r\n",
+            std::str::from_utf8(lock.get_ref())?
+        );
+    };
+
+    client.write_all(b"0123456789").await?;
+    client
+        .seek(SeekFrom::Start(REQUEST_WITH_EXPECT.len() as u64))
+        .await?;
+
+    assert_eq!("0123456789", request.body_string().await?);
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn test_without_expect_when_not_reading_body() -> Result<()> {
+    let client_str: Vec<u8> = REQUEST_WITH_EXPECT.to_vec();
+    let server_str: Vec<u8> = vec![];
+
+    let client = Arc::new(Mutex::new(Cursor::new(client_str)));
+    let server = Arc::new(Mutex::new(Cursor::new(server_str)));
+
+    async_h1::server::decode(Duplex::new(client.clone(), server.clone()))
+        .await?
+        .unwrap();
+
+    task::sleep(SLEEP_DURATION).await; // just long enough to wait for the channel
+
+    let server_lock = server.lock();
+    assert_eq!("", std::str::from_utf8(server_lock.get_ref())?); // we haven't written 100-continue
+
+    Ok(())
+}


### PR DESCRIPTION
closes #135. if a client says it expects 100-continue and we never read the body, we never send 100 continue and the client will have the option not to send a body.

this is implemented using a `ReadNotifier` which forwards BufRead and Read and sends a message on an async channel on first read. a task is spawned for each request which awaits that message and sends 100-continue.

the approach to testing might have been overkill for this pr, but hopefully sets us up to do other complex testing with async-h1