### PR TITLE
Allow chunked decoder to read-poll after eof

### DIFF
--- a/src/chunked/decoder.rs
+++ b/src/chunked/decoder.rs
@@ -207,6 +207,10 @@ impl<R: Read + Unpin> Read for ChunkedDecoder<R> {
     ) -> Poll<io::Result<usize>> {
         let this = &mut *self;
 
+        if let State::Done = this.state {
+            return Poll::Ready(Ok(0));
+        }
+
         let mut n = std::mem::replace(&mut this.current, 0..0);
         let buffer = std::mem::replace(&mut this.buffer, POOL.alloc(INITIAL_CAPACITY));
         let mut needs_read = !matches!(this.state, State::Chunk(_, _));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,8 @@
 //! }
 //! ```
 
-#![forbid(unsafe_code, rust_2018_idioms)]
-#![deny(missing_debug_implementations, nonstandard_style)]
+#![forbid(unsafe_code)]
+#![deny(missing_debug_implementations, nonstandard_style, rust_2018_idioms)]
 #![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 #![allow(clippy::if_same_then_else)]


### PR DESCRIPTION
closes #142 

async_std::io::copy needs to be able to read 0 several times while it waits for the writer to flush. Previously, we returned 0 once and then waited for further input, instead of returning 0 repeatedly once end-of-file has been hit. Maybe copy shouldn't be polling after eof, but that is a distinct concern.