### PR TITLE
For each header from an incoming request, use append instead of insert

### DIFF
--- a/src/server/decode.rs
+++ b/src/server/decode.rs
@@ -77,7 +77,7 @@ where
     req.set_version(Some(http_types::Version::Http1_1));
 
     for header in httparse_req.headers.iter() {
-        req.insert_header(header.name, std::str::from_utf8(header.value)?);
+        req.append_header(header.name, std::str::from_utf8(header.value)?);
     }
 
     let content_length = req.header(CONTENT_LENGTH);


### PR DESCRIPTION
Fixes #148 

When a request is decoded and contains multiple headers, in case there are multiple header values for the same header name, the current code will result in only the last header value being added to the map.

This PR uses `append_header` to ensure that if there are multiple header values to the same name, they're appended to the headers map.