### PR TITLE
move async-channel to dev deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ byte-pool = "0.2.1"
 lazy_static = "1.4.0"
 futures-core = "0.3.1"
 log = "0.4"
-async-channel = "1.5.1"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
@@ -29,3 +28,4 @@ tempfile = "3.1.0"
 async-test = "1.0.0"
 duplexify = "1.2.1"
 async-dup = "1.2.1"
+async-channel = "1.5.1"


### PR DESCRIPTION
I added it to cargo.toml before I realized that it was only needed for tests