### PR TITLE
address clippy concern about holding a sync mutex lock across an await boundary

### DIFF
--- a/tests/server.rs
+++ b/tests/server.rs
@@ -122,7 +122,7 @@ async fn test_unexpected_eof() {
 
 #[async_std::test]
 async fn test_invalid_trailer() {
-    let case = TestCase::new_server(
+    let mut case = TestCase::new_server(
         "fixtures/request-invalid-trailer.txt",
         "fixtures/response-invalid-trailer.txt",
     )


### PR DESCRIPTION
side note: async-dup is incredibly useful and maybe async-std should consider integrating it somehow, like maybe `async_std::io::{Arc, Mutex}`?

This is the clippy that this PR fixes, currently failing on main:
![image](https://user-images.githubusercontent.com/13301/99159872-b0048180-2695-11eb-8527-bf05a735f3bd.png)
