### PR TITLE
change: async-h1 endpoints always return a response

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -26,11 +26,11 @@ async fn main() -> http_types::Result<()> {
 // Take a TCP stream, and convert it into sequential HTTP request / response pairs.
 async fn accept(stream: TcpStream) -> http_types::Result<()> {
     println!("starting new connection from {}", stream.peer_addr()?);
-    async_h1::accept(stream.clone(), |_req| async move {
+    async_h1::accept(stream, |_req| async move {
         let mut res = Response::new(StatusCode::Ok);
         res.insert_header("Content-Type", "text/plain");
         res.set_body("Hello world");
-        Ok(res)
+        res
     })
     .await?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //!         let mut res = Response::new(StatusCode::Ok);
 //!         res.insert_header("Content-Type", "text/plain");
 //!         res.set_body("Hello");
-//!         Ok(res)
+//!         res
 //!     })
 //!     .await?;
 //!     Ok(())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,7 +35,7 @@ pub async fn accept<RW, F, Fut>(io: RW, endpoint: F) -> http_types::Result<()>
 where
     RW: Read + Write + Clone + Send + Sync + Unpin + 'static,
     F: Fn(Request) -> Fut,
-    Fut: Future<Output = http_types::Result<Response>>,
+    Fut: Future<Output = Response>,
 {
     Server::new(io, endpoint).accept().await
 }
@@ -51,7 +51,7 @@ pub async fn accept_with_opts<RW, F, Fut>(
 where
     RW: Read + Write + Clone + Send + Sync + Unpin + 'static,
     F: Fn(Request) -> Fut,
-    Fut: Future<Output = http_types::Result<Response>>,
+    Fut: Future<Output = Response>,
 {
     Server::new(io, endpoint).with_opts(opts).accept().await
 }
@@ -79,7 +79,7 @@ impl<RW, F, Fut> Server<RW, F, Fut>
 where
     RW: Read + Write + Clone + Send + Sync + Unpin + 'static,
     F: Fn(Request) -> Fut,
-    Fut: Future<Output = http_types::Result<Response>>,
+    Fut: Future<Output = Response>,
 {
     /// builds a new server
     pub fn new(io: RW, endpoint: F) -> Self {
@@ -108,7 +108,7 @@ where
     where
         RW: Read + Write + Clone + Send + Sync + Unpin + 'static,
         F: Fn(Request) -> Fut,
-        Fut: Future<Output = http_types::Result<Response>>,
+        Fut: Future<Output = Response>,
     {
         // Decode a new request, timing out if this takes longer than the timeout duration.
         let fut = decode(self.io.clone());
@@ -140,7 +140,7 @@ where
         let method = req.method();
 
         // Pass the request to the endpoint and encode the response.
-        let mut res = (self.endpoint)(req).await?;
+        let mut res = (self.endpoint)(req).await;
 
         close_connection |= res
             .header(CONNECTION)

--- a/tests/accept.rs
+++ b/tests/accept.rs
@@ -11,7 +11,7 @@ mod accept {
             let mut response = Response::new(200);
             let len = req.len();
             response.set_body(Body::from_reader(req, len));
-            Ok(response)
+            response
         });
 
         let content_length = 10;
@@ -35,7 +35,7 @@ mod accept {
 
     #[async_std::test]
     async fn request_close() -> Result<()> {
-        let mut server = TestServer::new(|_| async { Ok(Response::new(200)) });
+        let mut server = TestServer::new(|_| async { Response::new(200) });
 
         server
             .write_all(b"GET / HTTP/1.1\r\nHost: example.com\r\nConnection: Close\r\n\r\n")
@@ -53,7 +53,7 @@ mod accept {
         let mut server = TestServer::new(|_| async {
             let mut response = Response::new(200);
             response.insert_header(CONNECTION, "close");
-            Ok(response)
+            response
         });
 
         server
@@ -69,7 +69,7 @@ mod accept {
 
     #[async_std::test]
     async fn keep_alive_short_fixed_length_unread_body() -> Result<()> {
-        let mut server = TestServer::new(|_| async { Ok(Response::new(200)) });
+        let mut server = TestServer::new(|_| async { Response::new(200) });
 
         let content_length = 10;
 
@@ -95,7 +95,7 @@ mod accept {
 
     #[async_std::test]
     async fn keep_alive_short_chunked_unread_body() -> Result<()> {
-        let mut server = TestServer::new(|_| async { Ok(Response::new(200)) });
+        let mut server = TestServer::new(|_| async { Response::new(200) });
 
         let content_length = 100;
 
@@ -125,7 +125,7 @@ mod accept {
 
     #[async_std::test]
     async fn keep_alive_long_fixed_length_unread_body() -> Result<()> {
-        let mut server = TestServer::new(|_| async { Ok(Response::new(200)) });
+        let mut server = TestServer::new(|_| async { Response::new(200) });
 
         let content_length = 10000;
 
@@ -151,7 +151,7 @@ mod accept {
 
     #[async_std::test]
     async fn keep_alive_long_chunked_unread_body() -> Result<()> {
-        let mut server = TestServer::new(|_| async { Ok(Response::new(200)) });
+        let mut server = TestServer::new(|_| async { Response::new(200) });
 
         let content_length = 10000;
 

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -3,7 +3,7 @@ use async_h1::{
     server::{ConnectionStatus, Server},
 };
 use async_std::io::{Read, Write};
-use http_types::{Request, Response, Result};
+use http_types::{Request, Response};
 use std::{
     fmt::{Debug, Display},
     future::Future,
@@ -25,7 +25,7 @@ pub struct TestServer<F, Fut> {
 impl<F, Fut> TestServer<F, Fut>
 where
     F: Fn(Request) -> Fut,
-    Fut: Future<Output = Result<Response>>,
+    Fut: Future<Output = Response>,
 {
     #[allow(dead_code)]
     pub fn new(f: F) -> Self {
@@ -61,7 +61,7 @@ where
 impl<F, Fut> Read for TestServer<F, Fut>
 where
     F: Fn(Request) -> Fut,
-    Fut: Future<Output = Result<Response>>,
+    Fut: Future<Output = Response>,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -75,7 +75,7 @@ where
 impl<F, Fut> Write for TestServer<F, Fut>
 where
     F: Fn(Request) -> Fut,
-    Fut: Future<Output = Result<Response>>,
+    Fut: Future<Output = Response>,
 {
     fn poll_write(
         self: Pin<&mut Self>,


### PR DESCRIPTION
Async-h1 is a low-level library for use by other crates, and error handling within endpoint functions should be handled by higher levels of abstraction. From a http library's perspective, all requests must have a response.