### PR TITLE
Optional http/1.0 support

### DIFF
--- a/tests/continue.rs
+++ b/tests/continue.rs
@@ -16,7 +16,9 @@ async fn test_with_expect_when_reading_body() -> Result<()> {
     let (mut client, server) = TestIO::new();
     client.write_all(REQUEST_WITH_EXPECT).await?;
 
-    let (mut request, _) = async_h1::server::decode(server).await?.unwrap();
+    let (mut request, _) = async_h1::server::decode(server, &Default::default())
+        .await?
+        .unwrap();
 
     task::sleep(SLEEP_DURATION).await; //prove we're not just testing before we've written
 
@@ -44,7 +46,9 @@ async fn test_without_expect_when_not_reading_body() -> Result<()> {
     let (mut client, server) = TestIO::new();
     client.write_all(REQUEST_WITH_EXPECT).await?;
 
-    let (_, _) = async_h1::server::decode(server).await?.unwrap();
+    let (_, _) = async_h1::server::decode(server, &Default::default())
+        .await?
+        .unwrap();
 
     task::sleep(SLEEP_DURATION).await; // just long enough to wait for the channel
 

--- a/tests/server-chunked-encode-large.rs
+++ b/tests/server-chunked-encode-large.rs
@@ -76,7 +76,7 @@ async fn server_chunked_large() -> Result<()> {
     let (mut client, server) = TestIO::new();
     async_std::io::copy(&mut client::Encoder::new(request), &mut client).await?;
 
-    let (request, _) = server::decode(server).await?.unwrap();
+    let (request, _) = server::decode(server, &Default::default()).await?.unwrap();
 
     let mut response = Response::new(200);
     response.set_body(Body::from_reader(request, None));

--- a/tests/server_decode.rs
+++ b/tests/server_decode.rs
@@ -1,26 +1,31 @@
 mod test_utils;
 mod server_decode {
     use super::test_utils::TestIO;
+    use async_h1::ServerOptions;
     use async_std::io::prelude::*;
-    use http_types::headers::TRANSFER_ENCODING;
     use http_types::Request;
     use http_types::Result;
     use http_types::Url;
+    use http_types::{headers::TRANSFER_ENCODING, Version};
     use pretty_assertions::assert_eq;
 
-    async fn decode_lines(lines: Vec<&str>) -> Result<Option<Request>> {
+    async fn decode_lines(lines: Vec<&str>, options: ServerOptions) -> Result<Option<Request>> {
         let s = lines.join("\r\n");
         let (mut client, server) = TestIO::new();
         client.write_all(s.as_bytes()).await?;
         client.close();
-        async_h1::server::decode(server)
+        async_h1::server::decode(server, &options)
             .await
             .map(|r| r.map(|(r, _)| r))
     }
 
+    async fn decode_lines_default(lines: Vec<&str>) -> Result<Option<Request>> {
+        decode_lines(lines, ServerOptions::default()).await
+    }
+
     #[async_std::test]
     async fn post_with_body() -> Result<()> {
-        let mut request = decode_lines(vec![
+        let mut request = decode_lines_default(vec![
             "POST / HTTP/1.1",
             "host: localhost:8080",
             "content-length: 5",
@@ -53,7 +58,7 @@ mod server_decode {
 
     #[async_std::test]
     async fn chunked() -> Result<()> {
-        let mut request = decode_lines(vec![
+        let mut request = decode_lines_default(vec![
             "POST / HTTP/1.1",
             "host: localhost:8080",
             "transfer-encoding: chunked",
@@ -83,7 +88,7 @@ mod server_decode {
     "#]
     #[async_std::test]
     async fn invalid_trailer() -> Result<()> {
-        let mut request = decode_lines(vec![
+        let mut request = decode_lines_default(vec![
             "GET / HTTP/1.1",
             "host: domain.com",
             "content-type: application/octet-stream",
@@ -104,7 +109,7 @@ mod server_decode {
 
     #[async_std::test]
     async fn unexpected_eof() -> Result<()> {
-        let mut request = decode_lines(vec![
+        let mut request = decode_lines_default(vec![
             "POST / HTTP/1.1",
             "host: example.com",
             "content-type: text/plain",
@@ -123,6 +128,88 @@ mod server_decode {
         request.read_to_string(&mut string).await?;
         assert_eq!(string, "not 11");
 
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn http_1_0_without_host_header() -> Result<()> {
+        let request = decode_lines(
+            vec!["GET /path?query#fragment HTTP/1.0", "", ""],
+            ServerOptions::new().with_default_host("website.com"),
+        )
+        .await?
+        .unwrap();
+
+        assert_eq!(request.version(), Some(Version::Http1_0));
+        assert_eq!(
+            request.url().to_string(),
+            "http://website.com/path?query#fragment"
+        );
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn http_1_1_without_host_header() -> Result<()> {
+        let result = decode_lines(
+            vec!["GET /path?query#fragment HTTP/1.1", "", ""],
+            ServerOptions::default(),
+        )
+        .await;
+
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn http_1_0_with_host_header() -> Result<()> {
+        let request = decode_lines(
+            vec![
+                "GET /path?query#fragment HTTP/1.0",
+                "host: example.com",
+                "",
+                "",
+            ],
+            ServerOptions::new().with_default_host("website.com"),
+        )
+        .await?
+        .unwrap();
+
+        assert_eq!(request.version(), Some(Version::Http1_0));
+        assert_eq!(
+            request.url().to_string(),
+            "http://example.com/path?query#fragment"
+        );
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn http_1_0_request_with_no_default_host_is_provided() -> Result<()> {
+        let request = decode_lines(
+            vec!["GET /path?query#fragment HTTP/1.0", "", ""],
+            ServerOptions::default(),
+        )
+        .await;
+
+        assert!(request.is_err());
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn http_1_0_request_with_no_default_host_is_provided_even_if_host_header_exists(
+    ) -> Result<()> {
+        let result = decode_lines(
+            vec![
+                "GET /path?query#fragment HTTP/1.0",
+                "host: example.com",
+                "",
+                "",
+            ],
+            ServerOptions::default(),
+        )
+        .await;
+
+        assert!(result.is_err());
         Ok(())
     }
 }


### PR DESCRIPTION
this pr adds support for http/1.0, enabled by the `accept_with_opts` api caller providing a default host in ServerOptions. http frameworks like tide could surface this as a configuration option to the end user

There may be further work that needs to be done in order to completely support 1.0, but this addresses the biggest blocker and enables us to explore which of the other differences need to be handled at the async-h1 layer

Useful Reference: http://www.ra.ethz.ch/cdstore/www8/data/2136/pdf/pd1.pdf

closes #152
closes #122