### PR TITLE
Use concrete errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4.11"
 pin-project = "1.0.2"
 async-channel = "1.5.1"
 async-dup = "1.2.2"
+thiserror = "1.0.22"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 [dependencies]
 httparse = "1.3.4"
 async-std = "1.7.0"
-http-types = "2.9.0"
+http-types = { version = "2.9.0", default-features = false }
 byte-pool = "0.2.2"
 lazy_static = "1.4.0"
 futures-core = "0.3.8"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,7 @@ pub use decode::decode;
 pub use encode::Encoder;
 
 /// Opens an HTTP/1.1 connection to a remote host.
-pub async fn connect<RW>(mut stream: RW, req: Request) -> http_types::Result<Response>
+pub async fn connect<RW>(mut stream: RW, req: Request) -> crate::Result<Option<Response>>
 where
     RW: Read + Write + Send + Sync + Unpin + 'static,
 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,84 @@
+use std::str::Utf8Error;
+
+use http_types::url;
+use thiserror::Error;
+
+/// Concrete errors that occur within async-h1
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// [`std::io::Error`]
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
+
+    /// [`url::ParseError`]
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+
+    /// this error describes a malformed request with a path that does
+    /// not start with / or http:// or https://
+    #[error("unexpected uri format")]
+    UnexpectedURIFormat,
+
+    /// this error describes a http 1.1 request that is missing a Host
+    /// header
+    #[error("mandatory host header missing")]
+    HostHeaderMissing,
+
+    /// this error describes a request that does not specify a path
+    #[error("request path missing")]
+    RequestPathMissing,
+
+    /// [`httparse::Error`]
+    #[error(transparent)]
+    Httparse(#[from] httparse::Error),
+
+    /// an incomplete http head
+    #[error("partial http head")]
+    PartialHead,
+
+    /// we were unable to parse a header
+    #[error("malformed http header {0}")]
+    MalformedHeader(&'static str),
+
+    /// async-h1 doesn't speak this http version
+    /// this error is deprecated
+    #[error("unsupported http version 1.{0}")]
+    UnsupportedVersion(u8),
+
+    /// we were unable to parse this http method
+    #[error("unsupported http method {0}")]
+    UnrecognizedMethod(String),
+
+    /// this request did not have a method
+    #[error("missing method")]
+    MissingMethod,
+
+    /// this request did not have a status code
+    #[error("missing status code")]
+    MissingStatusCode,
+
+    /// we were unable to parse this http method
+    #[error("unrecognized http status code {0}")]
+    UnrecognizedStatusCode(u16),
+
+    /// this request did not have a version, but we expect one
+    /// this error is deprecated
+    #[error("missing version")]
+    MissingVersion,
+
+    /// we expected utf8, but there was an encoding error
+    #[error(transparent)]
+    EncodingError(#[from] Utf8Error),
+
+    /// we received a header that does not make sense in context
+    #[error("unexpected header: {0}")]
+    UnexpectedHeader(&'static str),
+
+    /// for security reasons, we do not allow request headers beyond 8kb.
+    #[error("Head byte length should be less than 8kb")]
+    HeadersTooLong,
+}
+
+/// this crate's result type
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,8 @@ use async_std::io::Cursor;
 use body_encoder::BodyEncoder;
 pub use client::connect;
 pub use server::{accept, accept_with_opts, ServerOptions};
+mod error;
+pub use error::{Error, Result};
 
 #[derive(Debug)]
 pub(crate) enum EncoderState {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -165,7 +165,9 @@ where
             .map(|connection| connection.as_str())
             .unwrap_or("");
 
-        let connection_header_is_upgrade = connection_header_as_str.eq_ignore_ascii_case("upgrade");
+        let connection_header_is_upgrade = connection_header_as_str
+            .split(',')
+            .any(|s| s.trim().eq_ignore_ascii_case("upgrade"));
 
         let mut close_connection = if req.version() == Some(Version::Http1_0) {
             !connection_header_as_str.eq_ignore_ascii_case("keep-alive")

--- a/tests/client_decode.rs
+++ b/tests/client_decode.rs
@@ -6,7 +6,7 @@ mod client_decode {
     use http_types::Result;
     use pretty_assertions::assert_eq;
 
-    async fn decode_lines(s: Vec<&str>) -> Result<Response> {
+    async fn decode_lines(s: Vec<&str>) -> async_h1::Result<Option<Response>> {
         client::decode(Cursor::new(s.join("\r\n"))).await
     }
 
@@ -19,7 +19,8 @@ mod client_decode {
             "",
             "",
         ])
-        .await?;
+        .await?
+        .unwrap();
 
         assert_eq!(res.header(&headers::DATE).is_some(), true);
         Ok(())
@@ -36,7 +37,8 @@ mod client_decode {
             "",
             "",
         ])
-        .await?;
+        .await?
+        .unwrap();
         assert_eq!(res.header(&headers::SET_COOKIE).unwrap().iter().count(), 2);
 
         Ok(())
@@ -53,15 +55,10 @@ mod client_decode {
             "http specifies headers are separated with \r\n but many servers don't do that",
             "",
         ])
-        .await?;
+        .await?
+        .unwrap();
 
-        assert_eq!(
-            res[headers::CONTENT_LENGTH]
-                .as_str()
-                .parse::<usize>()
-                .unwrap(),
-            78
-        );
+        assert_eq!(res[headers::CONTENT_LENGTH], "78");
 
         Ok(())
     }

--- a/tests/server-chunked-encode-large.rs
+++ b/tests/server-chunked-encode-large.rs
@@ -83,7 +83,7 @@ async fn server_chunked_large() -> Result<()> {
 
     let response_encoder = server::Encoder::new(response, Method::Get);
 
-    let mut response = client::decode(response_encoder).await?;
+    let mut response = client::decode(response_encoder).await?.unwrap();
 
     assert_eq!(response.body_string().await?, BODY);
     Ok(())

--- a/tests/server_decode.rs
+++ b/tests/server_decode.rs
@@ -14,9 +14,9 @@ mod server_decode {
         let (mut client, server) = TestIO::new();
         client.write_all(s.as_bytes()).await?;
         client.close();
-        async_h1::server::decode(server, &options)
+        Ok(async_h1::server::decode(server, &options)
             .await
-            .map(|r| r.map(|(r, _)| r))
+            .map(|r| r.map(|(r, _)| r))?)
     }
 
     async fn decode_lines_default(lines: Vec<&str>) -> Result<Option<Request>> {

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -37,7 +37,7 @@ where
     }
 
     #[allow(dead_code)]
-    pub async fn accept_one(&mut self) -> http_types::Result<ConnectionStatus> {
+    pub async fn accept_one(&mut self) -> async_h1::Result<ConnectionStatus> {
         self.server.accept_one().await
     }
 


### PR DESCRIPTION
using a dynamic error like anyhow is ideally suited to application code, not library code. async-h1 can enumerate every type of error that can occur, and it should do so.

we may want to revise the details of error enum before 3.0, but this represents a first effort at removing http_types::Error from async-h1.