### PR TITLE
return a 4xx status code on non-ascii headers

### DIFF
--- a/src/server/decode.rs
+++ b/src/server/decode.rs
@@ -80,6 +80,8 @@ where
     req.set_version(Some(http_types::Version::Http1_1));
 
     for header in httparse_req.headers.iter() {
+        // https://tools.ietf.org/html/rfc822#section-3.1
+        http_types::ensure_status!(header.value.is_ascii(), 400, "None ascii header");
         req.append_header(header.name, std::str::from_utf8(header.value)?);
     }
 


### PR DESCRIPTION
Hello,

`server::decode` panics on valid UTF-8 but none ASCII headers and return `500 Internal Server Error` on none valid UTF-8 headers.
I believe a `400 Bad Request` should be returned instead in both cases.

Note: Theorically the additional check will slightly decrease server side headers decoding performances. I am not sure about the project's policy, but usage of unsafe code `std::str::from_utf8_unchecked` could remove the performance penalty while remaining 100% safe. I have not benchmarked this at all however.

What do you think ?
Cheers.