### PR TITLE
fix firefox can't entablish websocket.

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -132,8 +132,7 @@ where
             .map(|connection| connection.as_str())
             .unwrap_or("");
 
-        let connection_header_is_upgrade = connection_header_as_str.split(',')
-            .any(|s| s.trim().eq_ignore_ascii_case("upgrade"));
+        let connection_header_is_upgrade = connection_header_as_str.split(',').any(|s| s.trim().eq_ignore_ascii_case("upgrade"));
         let mut close_connection = connection_header_as_str.eq_ignore_ascii_case("close");
 
         let upgrade_requested = has_upgrade_header && connection_header_is_upgrade;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -134,7 +134,7 @@ where
 
         let connection_header_is_upgrade = connection_header_as_str
             .split(',')
-            .any(|s| s.trim().eq_ignore_ascii_case("upgrade"));        
+            .any(|s| s.trim().eq_ignore_ascii_case("upgrade"));
         let mut close_connection = connection_header_as_str.eq_ignore_ascii_case("close");
 
         let upgrade_requested = has_upgrade_header && connection_header_is_upgrade;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -132,7 +132,6 @@ where
             .map(|connection| connection.as_str())
             .unwrap_or("");
 
-        let connection_header_is_upgrade = connection_header_as_str.split(',').any(|s| s.trim().eq_ignore_ascii_case("upgrade"));
         let connection_header_is_upgrade = connection_header_as_str
             .split(',')
             .any(|s| s.trim().eq_ignore_ascii_case("upgrade"));        

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -132,7 +132,8 @@ where
             .map(|connection| connection.as_str())
             .unwrap_or("");
 
-        let connection_header_is_upgrade = connection_header_as_str.eq_ignore_ascii_case("upgrade");
+        let connection_header_is_upgrade = connection_header_as_str.split(',')
+            .any(|s| s.trim().eq_ignore_ascii_case("upgrade"));
         let mut close_connection = connection_header_as_str.eq_ignore_ascii_case("close");
 
         let upgrade_requested = has_upgrade_header && connection_header_is_upgrade;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -133,6 +133,9 @@ where
             .unwrap_or("");
 
         let connection_header_is_upgrade = connection_header_as_str.split(',').any(|s| s.trim().eq_ignore_ascii_case("upgrade"));
+        let connection_header_is_upgrade = connection_header_as_str
+            .split(',')
+            .any(|s| s.trim().eq_ignore_ascii_case("upgrade"));        
         let mut close_connection = connection_header_as_str.eq_ignore_ascii_case("close");
 
         let upgrade_requested = has_upgrade_header && connection_header_is_upgrade;


### PR DESCRIPTION
firefox send websocket upgrade header "Connection:keep-alive, Upgrade" can't match with connection_header_as_str.eq_ignore_ascii_case("upgrade")