### PR TITLE
Disable default-features on http-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 [dependencies]
 httparse = "1.3.4"
 async-std = "1.7.0"
-http-types = "2.9.0"
+http-types = { version = "2.9.0", default-features = false }
 byte-pool = "0.2.2"
 lazy_static = "1.4.0"
 futures-core = "0.3.8"


### PR DESCRIPTION
With the next http-types release, this will allow omitting the cookie
feature and associated dependencies.