### PR TITLE
Proposal: Server side cancellation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4.11"
 pin-project = "1.0.2"
 async-channel = "1.5.1"
 async-dup = "1.2.2"
+stopper = "0.2.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"


### PR DESCRIPTION
Related PR: https://github.com/http-rs/tide/pull/836

This PR adds cancellation feature to Server with [stopper](https://crates.io/crates/stopper).

But I'm not sure it would shutdown the server 'gracefully'...