### PR TITLE
Rewrite `Transfer-Encoding: chunked` support to fix #195

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ edition = "2018"
 httparse = "1.3.4"
 async-std = "1.7.0"
 http-types = { version = "2.9.0", default-features = false }
-byte-pool = "0.2.2"
-lazy_static = "1.4.0"
 futures-core = "0.3.8"
 log = "0.4.11"
 pin-project = "1.0.2"

--- a/src/chunked/decoder.rs
+++ b/src/chunked/decoder.rs
@@ -1,21 +1,11 @@
 use std::fmt;
 use std::future::Future;
-use std::ops::Range;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use async_std::io::{self, Read};
-use async_std::sync::Arc;
-use byte_pool::{Block, BytePool};
+use futures_core::ready;
 use http_types::trailers::{Sender, Trailers};
-
-const INITIAL_CAPACITY: usize = 1024 * 4;
-const MAX_CAPACITY: usize = 512 * 1024 * 1024; // 512 MiB
-
-lazy_static::lazy_static! {
-    /// The global buffer pool we use for storing incoming data.
-    pub(crate) static ref POOL: Arc<BytePool> = Arc::new(BytePool::new());
-}
 
 /// Decodes a chunked body according to
 /// https://tools.ietf.org/html/rfc7230#section-4.1
@@ -23,15 +13,10 @@ lazy_static::lazy_static! {
 pub struct ChunkedDecoder<R: Read> {
     /// The underlying stream
     inner: R,
-    /// Buffer for the already read, but not yet parsed data.
-    buffer: Block<'static>,
-    /// Range of valid read data into buffer.
-    current: Range<usize>,
-    /// Whether we should attempt to decode whatever is currently inside the buffer.
-    /// False indicates that we know for certain that the buffer is incomplete.
-    initial_decode: bool,
     /// Current state.
     state: State,
+    /// Current chunk size (increased while parsing size, decreased while reading chunk)
+    chunk_size: u64,
     /// Trailer channel sender.
     trailer_sender: Option<Sender>,
 }
@@ -40,163 +25,98 @@ impl<R: Read> ChunkedDecoder<R> {
     pub(crate) fn new(inner: R, trailer_sender: Sender) -> Self {
         ChunkedDecoder {
             inner,
-            buffer: POOL.alloc(INITIAL_CAPACITY),
-            current: Range { start: 0, end: 0 },
-            initial_decode: false, // buffer is empty initially, nothing to decode}
-            state: State::Init,
+            state: State::ChunkSize,
+            chunk_size: 0,
             trailer_sender: Some(trailer_sender),
         }
     }
 }
 
+/// Decoder state.
+enum State {
+    /// Parsing bytes from a chunk size
+    ChunkSize,
+    /// Expecting the \n at the end of a chunk size
+    ChunkSizeExpectLf,
+    /// Parsing the chunk body
+    ChunkBody,
+    /// Expecting the \r at the end of a chunk body
+    ChunkBodyExpectCr,
+    /// Expecting the \n at the end of a chunk body
+    ChunkBodyExpectLf,
+    /// Parsing trailers.
+    Trailers(usize, Box<[u8; 8192]>),
+    /// Sending trailers over the channel.
+    TrailerSending(Pin<Box<dyn Future<Output = ()> + 'static + Send + Sync>>),
+    /// All is said and done.
+    Done,
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            State::ChunkSize => write!(f, "State::ChunkSize"),
+            State::ChunkSizeExpectLf => write!(f, "State::ChunkSizeExpectLf"),
+            State::ChunkBody => write!(f, "State::ChunkBody"),
+            State::ChunkBodyExpectCr => write!(f, "State::ChunkBodyExpectCr"),
+            State::ChunkBodyExpectLf => write!(f, "State::ChunkBodyExpectLf"),
+            State::Trailers(len, _) => write!(f, "State::Trailers({}, _)", len),
+            State::TrailerSending(_) => write!(f, "State::TrailerSending"),
+            State::Done => write!(f, "State::Done"),
+        }
+    }
+}
+
 impl<R: Read + Unpin> ChunkedDecoder<R> {
-    fn poll_read_chunk(
-        &mut self,
-        cx: &mut Context<'_>,
-        buffer: Block<'static>,
-        pos: &Range<usize>,
-        buf: &mut [u8],
-        current: u64,
-        len: u64,
-    ) -> io::Result<DecodeResult> {
-        let mut new_pos = pos.clone();
-        let remaining = (len - current) as usize;
-        let to_read = std::cmp::min(remaining, buf.len());
-
-        let mut new_current = current;
-
-        // position into buf
-        let mut read = 0;
-
-        // first drain the buffer
-        if new_pos.len() > 0 {
-            let to_read_buf = std::cmp::min(to_read, pos.len());
-            buf[..to_read_buf].copy_from_slice(&buffer[new_pos.start..new_pos.start + to_read_buf]);
-
-            if new_pos.start + to_read_buf == new_pos.end {
-                new_pos = 0..0
-            } else {
-                new_pos.start += to_read_buf;
-            }
-            new_current += to_read_buf as u64;
-            read += to_read_buf;
-
-            let new_state = if new_current == len {
-                State::ChunkEnd
-            } else {
-                State::Chunk(new_current, len)
-            };
-
-            return Ok(DecodeResult::Some {
-                read,
-                new_state: Some(new_state),
-                new_pos,
-                buffer,
-                pending: false,
-            });
-        }
-
-        // attempt to fill the buffer
-        match Pin::new(&mut self.inner).poll_read(cx, &mut buf[read..read + to_read]) {
-            Poll::Ready(val) => {
-                let n = val?;
-                new_current += n as u64;
-                read += n;
-                let new_state = if new_current == len {
-                    State::ChunkEnd
-                } else if n == 0 {
-                    // Unexpected end
-                    // TODO: do something?
-                    State::Done
-                } else {
-                    State::Chunk(new_current, len)
-                };
-
-                Ok(DecodeResult::Some {
-                    read,
-                    new_state: Some(new_state),
-                    new_pos,
-                    buffer,
-                    pending: false,
-                })
-            }
-            Poll::Pending => Ok(DecodeResult::Some {
-                read: 0,
-                new_state: Some(State::Chunk(new_current, len)),
-                new_pos,
-                buffer,
-                pending: true,
-            }),
+    fn poll_read_byte(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<u8>> {
+        let mut byte = [0u8];
+        if ready!(Pin::new(&mut self.inner).poll_read(cx, &mut byte))? == 1 {
+            Poll::Ready(Ok(byte[0]))
+        } else {
+            eof()
         }
     }
 
-    fn poll_read_inner(
+    fn expect_byte(
         &mut self,
         cx: &mut Context<'_>,
-        buffer: Block<'static>,
-        pos: &Range<usize>,
-        buf: &mut [u8],
-    ) -> io::Result<DecodeResult> {
-        match self.state {
-            State::Init => {
-                // Initial read
-                decode_init(buffer, pos)
-            }
-            State::Chunk(current, len) => {
-                // reading a chunk
-                self.poll_read_chunk(cx, buffer, pos, buf, current, len)
-            }
-            State::ChunkEnd => decode_chunk_end(buffer, pos),
-            State::Trailer => {
-                // reading the trailer headers
-                decode_trailer(buffer, pos)
-            }
-            State::TrailerDone(ref mut headers) => {
-                let headers = std::mem::replace(headers, Trailers::new());
-                let sender = self.trailer_sender.take();
-                let sender =
-                    sender.expect("invalid chunked state, tried sending multiple trailers");
-
-                let fut = Box::pin(sender.send(headers));
-                Ok(DecodeResult::Some {
-                    read: 0,
-                    new_state: Some(State::TrailerSending(fut)),
-                    new_pos: pos.clone(),
-                    buffer,
-                    pending: false,
-                })
-            }
-            State::TrailerSending(ref mut fut) => {
-                match Pin::new(fut).poll(cx) {
-                    Poll::Ready(_) => {}
-                    Poll::Pending => {
-                        return Ok(DecodeResult::Some {
-                            read: 0,
-                            new_state: None,
-                            new_pos: pos.clone(),
-                            buffer,
-                            pending: true,
-                        });
-                    }
-                }
-
-                Ok(DecodeResult::Some {
-                    read: 0,
-                    new_state: Some(State::Done),
-                    new_pos: pos.clone(),
-                    buffer,
-                    pending: false,
-                })
-            }
-            State::Done => Ok(DecodeResult::Some {
-                read: 0,
-                new_state: Some(State::Done),
-                new_pos: pos.clone(),
-                buffer,
-                pending: false,
-            }),
+        expected_byte: u8,
+        expected: &'static str,
+    ) -> Poll<io::Result<()>> {
+        let byte = ready!(self.poll_read_byte(cx))?;
+        if byte == expected_byte {
+            Poll::Ready(Ok(()))
+        } else {
+            unexpected(byte, expected)
         }
     }
+
+    fn send_trailers(&mut self, trailers: Trailers) {
+        let sender = self
+            .trailer_sender
+            .take()
+            .expect("invalid chunked state, tried sending multiple trailers");
+        let fut = Box::pin(sender.send(trailers));
+        self.state = State::TrailerSending(fut);
+    }
+}
+
+fn eof<T>() -> Poll<io::Result<T>> {
+    Poll::Ready(Err(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "Unexpected EOF when decoding chunked data",
+    )))
+}
+
+fn unexpected<T>(byte: u8, expected: &'static str) -> Poll<io::Result<T>> {
+    Poll::Ready(Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("Unexpected byte {}; expected {}", byte, expected),
+    )))
+}
+
+fn overflow() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "Chunk size overflowed 64 bits")
 }
 
 impl<R: Read + Unpin> Read for ChunkedDecoder<R> {
@@ -208,298 +128,106 @@ impl<R: Read + Unpin> Read for ChunkedDecoder<R> {
     ) -> Poll<io::Result<usize>> {
         let this = &mut *self;
 
-        if let State::Done = this.state {
-            return Poll::Ready(Ok(0));
-        }
-
-        let mut n = std::mem::replace(&mut this.current, 0..0);
-        let buffer = std::mem::replace(&mut this.buffer, POOL.alloc(INITIAL_CAPACITY));
-        let mut needs_read = !matches!(this.state, State::Chunk(_, _));
-
-        let mut buffer = if n.len() > 0 && this.initial_decode {
-            // initial buffer filling, if needed
-            match this.poll_read_inner(cx, buffer, &n, buf)? {
-                DecodeResult::Some {
-                    read,
-                    buffer,
-                    new_pos,
-                    new_state,
-                    pending,
-                } => {
-                    this.current = new_pos.clone();
-                    if let Some(state) = new_state {
-                        this.state = state;
-                    }
-
-                    if pending {
-                        // initial_decode is still true
-                        this.buffer = buffer;
-                        return Poll::Pending;
-                    }
-
-                    if let State::Done = this.state {
-                        // initial_decode is still true
-                        this.buffer = buffer;
-                        return Poll::Ready(Ok(read));
-                    }
-
-                    if read > 0 {
-                        // initial_decode is still true
-                        this.buffer = buffer;
-                        return Poll::Ready(Ok(read));
-                    }
-
-                    n = new_pos;
-                    needs_read = false;
-                    buffer
-                }
-                DecodeResult::None(buffer) => buffer,
-            }
-        } else {
-            buffer
-        };
-
         loop {
-            if n.len() >= buffer.capacity() {
-                if buffer.capacity() + 1024 <= MAX_CAPACITY {
-                    buffer.realloc(buffer.capacity() + 1024);
-                } else {
-                    this.buffer = buffer;
-                    this.current = n;
-                    return Poll::Ready(Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "incoming data too large",
-                    )));
+            match this.state {
+                State::ChunkSize => {
+                    let byte = ready!(this.poll_read_byte(cx))?;
+                    let digit = match byte {
+                        b'0'..=b'9' => byte - b'0',
+                        b'a'..=b'f' => 10 + byte - b'a',
+                        b'A'..=b'F' => 10 + byte - b'A',
+                        b'\r' => {
+                            this.state = State::ChunkSizeExpectLf;
+                            continue;
+                        }
+                        _ => {
+                            return unexpected(byte, "hex digit or CR");
+                        }
+                    };
+                    this.chunk_size = this
+                        .chunk_size
+                        .checked_mul(16)
+                        .ok_or_else(overflow)?
+                        .checked_add(digit as u64)
+                        .ok_or_else(overflow)?;
                 }
-            }
-
-            if needs_read {
-                let bytes_read = match Pin::new(&mut this.inner).poll_read(cx, &mut buffer[n.end..])
-                {
-                    Poll::Ready(result) => result?,
-                    Poll::Pending => {
-                        // if we're here, it means that we need more data but there is none yet,
-                        // so no decoding attempts are necessary until we get more data
-                        this.initial_decode = false;
-                        this.buffer = buffer;
-                        this.current = n;
-                        return Poll::Pending;
-                    }
-                };
-                match (bytes_read, &this.state) {
-                    (0, State::Done) => {}
-                    (0, _) => {
-                        // Unexpected end
-                        // TODO: do something?
-                        this.state = State::Done;
-                    }
-                    _ => {}
-                }
-                n.end += bytes_read;
-            }
-            match this.poll_read_inner(cx, buffer, &n, buf)? {
-                DecodeResult::Some {
-                    read,
-                    buffer: new_buffer,
-                    new_pos,
-                    new_state,
-                    pending,
-                } => {
-                    // current buffer might now contain more data inside, so we need to attempt
-                    // to decode it next time
-                    this.initial_decode = true;
-                    if let Some(state) = new_state {
-                        this.state = state;
-                    }
-                    this.current = new_pos.clone();
-                    n = new_pos;
-
-                    if let State::Done = this.state {
-                        this.buffer = new_buffer;
-                        return Poll::Ready(Ok(read));
-                    }
-
-                    if read > 0 {
-                        this.buffer = new_buffer;
-                        return Poll::Ready(Ok(read));
-                    }
-
-                    if pending {
-                        this.buffer = new_buffer;
-                        return Poll::Pending;
-                    }
-
-                    buffer = new_buffer;
-                    needs_read = false;
-                    continue;
-                }
-                DecodeResult::None(buf) => {
-                    buffer = buf;
-
-                    if this.buffer.is_empty() || n.start == 0 && n.end == 0 {
-                        // "logical buffer" is empty, there is nothing to decode on the next step
-                        this.initial_decode = false;
-                        this.buffer = buffer;
-                        this.current = n;
-
-                        return Poll::Ready(Ok(0));
+                State::ChunkSizeExpectLf => {
+                    ready!(this.expect_byte(cx, b'\n', "LF"))?;
+                    if this.chunk_size == 0 {
+                        this.state = State::Trailers(0, Box::new([0u8; 8192]));
                     } else {
-                        needs_read = true;
+                        this.state = State::ChunkBody;
                     }
                 }
+                State::ChunkBody => {
+                    let max_bytes = std::cmp::min(
+                        buf.len(),
+                        std::cmp::min(this.chunk_size, usize::MAX as u64) as usize,
+                    );
+                    let bytes_read =
+                        ready!(Pin::new(&mut this.inner).poll_read(cx, &mut buf[..max_bytes]))?;
+                    this.chunk_size -= bytes_read as u64;
+                    if bytes_read == 0 {
+                        return eof();
+                    } else if this.chunk_size == 0 {
+                        this.state = State::ChunkBodyExpectCr;
+                    }
+                    return Poll::Ready(Ok(bytes_read));
+                }
+                State::ChunkBodyExpectCr => {
+                    ready!(this.expect_byte(cx, b'\r', "CR"))?;
+                    this.state = State::ChunkBodyExpectLf;
+                }
+                State::ChunkBodyExpectLf => {
+                    ready!(this.expect_byte(cx, b'\n', "LF"))?;
+                    this.state = State::ChunkSize;
+                }
+                State::Trailers(ref mut len, ref mut buf) => {
+                    let bytes_read =
+                        ready!(Pin::new(&mut this.inner).poll_read(cx, &mut buf[*len..]))?;
+                    *len += bytes_read;
+                    let len = *len;
+                    if len == 0 {
+                        this.send_trailers(Trailers::new());
+                        continue;
+                    }
+                    if bytes_read == 0 {
+                        return eof();
+                    }
+                    let mut headers = [httparse::EMPTY_HEADER; 16];
+                    let parse_result = httparse::parse_headers(&buf[..len], &mut headers)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                    use httparse::Status;
+                    match parse_result {
+                        Status::Partial => {
+                            if len == buf.len() {
+                                return eof();
+                            } else {
+                                return Poll::Pending;
+                            }
+                        }
+                        Status::Complete((offset, headers)) => {
+                            if offset != len {
+                                return unexpected(buf[offset], "end of trailers");
+                            }
+                            let mut trailers = Trailers::new();
+                            for header in headers {
+                                trailers.insert(
+                                    header.name,
+                                    String::from_utf8_lossy(header.value).as_ref(),
+                                );
+                            }
+                            this.send_trailers(trailers);
+                        }
+                    }
+                }
+                State::TrailerSending(ref mut fut) => {
+                    let _ = ready!(Pin::new(fut).poll(cx));
+                    this.state = State::Done;
+                }
+                State::Done => return Poll::Ready(Ok(0)),
             }
         }
-    }
-}
-
-/// Possible return values from calling `decode` methods.
-enum DecodeResult {
-    /// Something was decoded successfully.
-    Some {
-        /// How much data was read.
-        read: usize,
-        /// The passed in block returned.
-        buffer: Block<'static>,
-        /// The new range of valid data in `buffer`.
-        new_pos: Range<usize>,
-        /// The new state.
-        new_state: Option<State>,
-        /// Should poll return `Pending`.
-        pending: bool,
-    },
-    /// Nothing was decoded.
-    None(Block<'static>),
-}
-
-/// Decoder state.
-enum State {
-    /// Initial state.
-    Init,
-    /// Decoding a chunk, first value is the current position, second value is the length of the chunk.
-    Chunk(u64, u64),
-    /// Decoding the end part of a chunk.
-    ChunkEnd,
-    /// Decoding trailers.
-    Trailer,
-    /// Trailers were decoded, are now set to the decoded trailers.
-    TrailerDone(Trailers),
-    TrailerSending(Pin<Box<dyn Future<Output = ()> + 'static + Send + Sync>>),
-    /// All is said and done.
-    Done,
-}
-impl fmt::Debug for State {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use State::*;
-        match self {
-            Init => write!(f, "State::Init"),
-            Chunk(a, b) => write!(f, "State::Chunk({}, {})", a, b),
-            ChunkEnd => write!(f, "State::ChunkEnd"),
-            Trailer => write!(f, "State::Trailer"),
-            TrailerDone(trailers) => write!(f, "State::TrailerDone({:?})", &trailers),
-            TrailerSending(_) => write!(f, "State::TrailerSending"),
-            Done => write!(f, "State::Done"),
-        }
-    }
-}
-
-impl fmt::Debug for DecodeResult {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DecodeResult::Some {
-                read,
-                buffer,
-                new_pos,
-                new_state,
-                pending,
-            } => f
-                .debug_struct("DecodeResult::Some")
-                .field("read", read)
-                .field("block", &buffer.len())
-                .field("new_pos", new_pos)
-                .field("new_state", new_state)
-                .field("pending", pending)
-                .finish(),
-            DecodeResult::None(block) => write!(f, "DecodeResult::None({})", block.len()),
-        }
-    }
-}
-
-fn decode_init(buffer: Block<'static>, pos: &Range<usize>) -> io::Result<DecodeResult> {
-    use httparse::Status;
-    match httparse::parse_chunk_size(&buffer[pos.start..pos.end]) {
-        Ok(Status::Complete((used, chunk_len))) => {
-            let new_pos = Range {
-                start: pos.start + used,
-                end: pos.end,
-            };
-
-            let new_state = if chunk_len == 0 {
-                State::Trailer
-            } else {
-                State::Chunk(0, chunk_len)
-            };
-
-            Ok(DecodeResult::Some {
-                read: 0,
-                buffer,
-                new_pos,
-                new_state: Some(new_state),
-                pending: false,
-            })
-        }
-        Ok(Status::Partial) => Ok(DecodeResult::None(buffer)),
-        Err(err) => Err(io::Error::new(io::ErrorKind::Other, err.to_string())),
-    }
-}
-
-fn decode_chunk_end(buffer: Block<'static>, pos: &Range<usize>) -> io::Result<DecodeResult> {
-    if pos.len() < 2 {
-        return Ok(DecodeResult::None(buffer));
-    }
-
-    if &buffer[pos.start..pos.start + 2] == b"\r\n" {
-        // valid chunk end move on to a new header
-        return Ok(DecodeResult::Some {
-            read: 0,
-            buffer,
-            new_pos: Range {
-                start: pos.start + 2,
-                end: pos.end,
-            },
-            new_state: Some(State::Init),
-            pending: false,
-        });
-    }
-
-    Err(io::Error::from(io::ErrorKind::InvalidData))
-}
-
-fn decode_trailer(buffer: Block<'static>, pos: &Range<usize>) -> io::Result<DecodeResult> {
-    use httparse::Status;
-
-    // read headers
-    let mut headers = [httparse::EMPTY_HEADER; 16];
-
-    match httparse::parse_headers(&buffer[pos.start..pos.end], &mut headers) {
-        Ok(Status::Complete((used, headers))) => {
-            let mut trailers = Trailers::new();
-            for header in headers {
-                trailers.insert(header.name, String::from_utf8_lossy(header.value).as_ref());
-            }
-
-            Ok(DecodeResult::Some {
-                read: 0,
-                buffer,
-                new_state: Some(State::TrailerDone(trailers)),
-                new_pos: Range {
-                    start: pos.start + used,
-                    end: pos.end,
-                },
-                pending: false,
-            })
-        }
-        Ok(Status::Partial) => Ok(DecodeResult::None(buffer)),
-        Err(err) => Err(io::Error::new(io::ErrorKind::Other, err.to_string())),
     }
 }
 

--- a/src/server/decode.rs
+++ b/src/server/decode.rs
@@ -127,7 +127,7 @@ where
         let reader = ReadNotifier::new(reader, body_read_sender);
         let reader = BufReader::new(reader);
         req.set_body(Body::from_reader(reader, None));
-        return Ok(Some((req, BodyReader::Chunked(reader_clone))));
+        Ok(Some((req, BodyReader::Chunked(reader_clone))))
     } else if let Some(len) = content_length {
         let len = len.len();
         let reader = Arc::new(Mutex::new(reader.take(len)));

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -170,7 +170,7 @@ where
 
         if let Some(upgrade_sender) = upgrade_sender {
             upgrade_sender.send(Connection::new(self.io.clone())).await;
-            return Ok(ConnectionStatus::Close);
+            Ok(ConnectionStatus::Close)
         } else if close_connection {
             Ok(ConnectionStatus::Close)
         } else {

--- a/tests/client_decode.rs
+++ b/tests/client_decode.rs
@@ -26,7 +26,7 @@ mod client_decode {
         ])
         .await?;
 
-        assert_eq!(res.header(&headers::DATE).is_some(), true);
+        assert!(res.header(&headers::DATE).is_some());
         Ok(())
     }
 


### PR DESCRIPTION
This simplifies and shortens the implementation, and fixes the bug in the process.

This now parses offsets byte-at-a-time.