### PR TITLE
Replace async-std with smol crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ edition = "2018"
 
 [dependencies]
 httparse = "1.3.4"
-async-std = "1.7.0"
 http-types = { version = "2.9.0", default-features = false }
 futures-core = "0.3.8"
 log = "0.4.11"
@@ -28,6 +27,7 @@ async-channel = "1.5.1"
 async-dup = "1.2.2"
 futures-lite = "1.13.0"
 async-io = "1.13.0"
+async-global-executor = "2.3.1"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,17 +18,16 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-httparse = "1.3.4"
-http-types = { version = "2.9.0", default-features = false }
-futures-core = "0.3.8"
-log = "0.4.11"
-pin-project = "1.0.2"
 async-channel = "1.5.1"
 async-dup = "1.2.2"
-futures-lite = "1.13.0"
-async-io = "1.13.0"
 async-global-executor = "2.3.1"
+async-io = "1.13.0"
+futures-lite = "1.13.0"
+http-types = { version = "2.9.0", default-features = false }
+httparse = "1.3.4"
+log = "0.4.11"
+pin-project = "1.0.2"
 
 [dev-dependencies]
-pretty_assertions = "0.6.1"
 async-std = { version = "1.7.0", features = ["attributes"] }
+pretty_assertions = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ log = "0.4.11"
 pin-project = "1.0.2"
 async-channel = "1.5.1"
 async-dup = "1.2.2"
+futures-lite = "1.13.0"
+async-io = "1.13.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/body_encoder.rs
+++ b/src/body_encoder.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use async_std::io::Read;
+use futures_lite::io::AsyncRead as Read;
 use http_types::Body;
 use pin_project::pin_project;
 

--- a/src/chunked/decoder.rs
+++ b/src/chunked/decoder.rs
@@ -3,8 +3,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use async_std::io::{self, Read};
-use futures_core::ready;
+use futures_lite::io::{self, AsyncRead as Read};
+use futures_lite::ready;
 use http_types::trailers::{Sender, Trailers};
 
 /// Decodes a chunked body according to

--- a/src/chunked/encoder.rs
+++ b/src/chunked/encoder.rs
@@ -1,9 +1,8 @@
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use async_std::io;
-use async_std::io::prelude::*;
-use async_std::task::{Context, Poll};
-use futures_core::ready;
+use futures_lite::io::AsyncRead as Read;
+use futures_lite::{io, ready};
 
 /// An encoder for chunked encoding.
 #[derive(Debug)]

--- a/src/client/decode.rs
+++ b/src/client/decode.rs
@@ -1,5 +1,5 @@
-use async_std::io::{BufReader, Read};
-use async_std::prelude::*;
+use futures_lite::io::{AsyncRead as Read, BufReader};
+use futures_lite::prelude::*;
 use http_types::{ensure, ensure_eq, format_err};
 use http_types::{
     headers::{CONTENT_LENGTH, DATE, TRANSFER_ENCODING},

--- a/src/client/encode.rs
+++ b/src/client/encode.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use async_std::io::{self, Cursor, Read};
-use async_std::task::{Context, Poll};
+use futures_lite::io::{self, AsyncRead as Read, Cursor};
 use http_types::headers::{CONTENT_LENGTH, HOST, TRANSFER_ENCODING};
 use http_types::{Method, Request};
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,6 @@
 //! Process HTTP connections on the client.
 
-use async_std::io::{self, Read, Write};
+use futures_lite::io::{self, AsyncRead as Read, AsyncWrite as Write};
 use http_types::{Request, Response};
 
 mod decode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,9 +112,9 @@ mod read_notifier;
 pub mod client;
 pub mod server;
 
-use async_std::io::Cursor;
 use body_encoder::BodyEncoder;
 pub use client::connect;
+use futures_lite::io::Cursor;
 pub use server::{accept, accept_with_opts, ServerOptions};
 
 #[derive(Debug)]

--- a/src/read_notifier.rs
+++ b/src/read_notifier.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use async_channel::Sender;
-use async_std::io::{self, BufRead, Read};
+use futures_lite::io::{self, AsyncBufRead as BufRead, AsyncRead as Read};
 
 /// ReadNotifier forwards [`async_std::io::Read`] and
 /// [`async_std::io::BufRead`] to an inner reader. When the

--- a/src/server/body_reader.rs
+++ b/src/server/body_reader.rs
@@ -1,8 +1,12 @@
 use crate::chunked::ChunkedDecoder;
 use async_dup::{Arc, Mutex};
-use async_std::io::{BufReader, Read, Take};
-use async_std::task::{Context, Poll};
-use std::{fmt::Debug, io, pin::Pin};
+use futures_lite::io::{AsyncRead as Read, BufReader, Take};
+use std::{
+    fmt::Debug,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 pub enum BodyReader<IO: Read + Unpin> {
     Chunked(Arc<Mutex<ChunkedDecoder<BufReader<IO>>>>),

--- a/src/server/decode.rs
+++ b/src/server/decode.rs
@@ -3,8 +3,9 @@
 use std::str::FromStr;
 
 use async_dup::{Arc, Mutex};
-use async_std::io::{BufReader, Read, Write};
-use async_std::{prelude::*, task};
+use async_std::task;
+use futures_lite::io::{AsyncRead as Read, AsyncWrite as Write, BufReader};
+use futures_lite::prelude::*;
 use http_types::content::ContentLength;
 use http_types::headers::{EXPECT, TRANSFER_ENCODING};
 use http_types::{ensure, ensure_eq, format_err};

--- a/src/server/decode.rs
+++ b/src/server/decode.rs
@@ -3,7 +3,6 @@
 use std::str::FromStr;
 
 use async_dup::{Arc, Mutex};
-use async_std::task;
 use futures_lite::io::{AsyncRead as Read, AsyncWrite as Write, BufReader};
 use futures_lite::prelude::*;
 use http_types::content::ContentLength;
@@ -104,7 +103,7 @@ where
     let (body_read_sender, body_read_receiver) = async_channel::bounded(1);
 
     if Some(CONTINUE_HEADER_VALUE) == req.header(EXPECT).map(|h| h.as_str()) {
-        task::spawn(async move {
+        async_global_executor::spawn(async move {
             // If the client expects a 100-continue header, spawn a
             // task to wait for the first read attempt on the body.
             if let Ok(()) = body_read_receiver.recv().await {
@@ -113,7 +112,8 @@ where
             // Since the sender is moved into the Body, this task will
             // finish when the client disconnects, whether or not
             // 100-continue was sent.
-        });
+        })
+        .detach();
     }
 
     // Check for Transfer-Encoding

--- a/src/server/encode.rs
+++ b/src/server/encode.rs
@@ -2,10 +2,10 @@
 
 use std::io::Write;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::SystemTime;
 
-use async_std::io::{self, Cursor, Read};
-use async_std::task::{Context, Poll};
+use futures_lite::io::{self, AsyncRead as Read, Cursor};
 use http_types::headers::{CONTENT_LENGTH, DATE, TRANSFER_ENCODING};
 use http_types::{Method, Response};
 


### PR DESCRIPTION
It would be nice to be able to use this in environments where I use
smol. However this crate imports the async-std crate for I/O. This
commit partially replaces async-std with the equivalent combinators from
futures-lite and async-io, two smol crates that async-std depends on
anyways.

The task spawn is still left in, as replacing it will be controversial. Thus far I've just replaced it with `async-global-executor`, which is what `async-std` uses anyways. This is a placeholder until we can discuss what the best way of not using a global executor is.